### PR TITLE
Channel reorganization plus some other changes

### DIFF
--- a/Sources/SwiftDiscord/DiscordChannel.swift
+++ b/Sources/SwiftDiscord/DiscordChannel.swift
@@ -24,8 +24,15 @@ public protocol DiscordChannel : DiscordClientHolder {
     /// The id of the channel.
     var id: String { get }
 
-    /// The type of the channel
-    var type: DiscordChannelType { get }
+    /// Whether or not the channel is private
+    var isPrivate: Bool { get }
+}
+
+/// Protocol that declares a type will be a Discord text-based channel.
+public protocol DiscordTextChannel : DiscordChannel {
+
+    /// The snowflake id of the last received message on this channel.
+    var lastMessageId: String { get }
 }
 
 /// Represents the type of a channel.
@@ -54,17 +61,6 @@ public extension DiscordChannel {
     // MARK: Methods
 
     /**
-        Pins a message to this channel.
-
-        - parameter message: The message to pin
-    */
-    public func pinMessage(_ message: DiscordMessage) {
-        guard let client = self.client else { return }
-
-        client.addPinnedMessage(message.id, on: id)
-    }
-
-    /**
         Deletes this channel.
     */
     public func delete() {
@@ -73,6 +69,34 @@ public extension DiscordChannel {
         DefaultDiscordLogger.Logger.log("Deleting channel: %@", type: "DiscordChannel", args: id)
 
         client.deleteChannel(id)
+    }
+
+    /**
+        Modifies this channel with `options`.
+
+        - parameter options: An array of `DiscordEndpointOptions.ModifyChannel`
+    */
+    public func modifyChannel(options: [DiscordEndpoint.Options.ModifyChannel]) {
+        guard let client = self.client else { return }
+
+        client.modifyChannel(id, options: options)
+    }
+
+
+}
+
+public extension DiscordTextChannel {
+    // MARK: Text Channel Methods
+
+    /**
+     Pins a message to this channel.
+
+     - parameter message: The message to pin
+     */
+    public func pinMessage(_ message: DiscordMessage) {
+        guard let client = self.client else { return }
+
+        client.addPinnedMessage(message.id, on: id)
     }
 
     /**
@@ -113,17 +137,6 @@ public extension DiscordChannel {
     }
 
     /**
-        Modifies this channel with `options`.
-
-        - parameter options: An array of `DiscordEndpointOptions.ModifyChannel`
-    */
-    public func modifyChannel(options: [DiscordEndpoint.Options.ModifyChannel]) {
-        guard let client = self.client else { return }
-
-        client.modifyChannel(id, options: options)
-    }
-
-    /**
         Sends a message to this channel. Can be used to send embeds and files as well.
 
         ```swift
@@ -145,7 +158,7 @@ public extension DiscordChannel {
         - parameter message: The message to send.
     */
     public func send(_ message: DiscordMessage) {
-        guard let client = self.client, type != .voice else { return }
+        guard let client = self.client else { return }
 
         client.sendMessage(message, to: id)
     }
@@ -171,22 +184,22 @@ public extension DiscordChannel {
     }
 }
 
-func channelFromObject(_ object: [String: Any], withClient client: DiscordClient) -> DiscordChannel? {
+func channelFromObject(_ object: [String: Any], withClient client: DiscordClient?) -> DiscordChannel? {
     guard let type = DiscordChannelType(rawValue: object.get("type", or: -1)) else { return nil }
 
     switch type {
-    case .text:     fallthrough
-    case .voice:    return DiscordGuildChannel(guildChannelObject: object, client: client)
+    case .text:     return DiscordGuildTextChannel(guildChannelObject: object, client: client)
+    case .voice:    return DiscordGuildVoiceChannel(guildChannelObject: object, client: client)
     case .direct:   return DiscordDMChannel(dmReadyObject: object, client: client)
     case .groupDM:  return DiscordGroupDMChannel(dmReadyObject: object, client: client)
     }
 }
 
-func privateChannelsFromArray(_ channels: [[String: Any]], client: DiscordClient) -> [String: DiscordChannel] {
-    var channelDict = [String: DiscordChannel]()
+func privateChannelsFromArray(_ channels: [[String: Any]], client: DiscordClient) -> [String: DiscordTextChannel] {
+    var channelDict = [String: DiscordTextChannel]()
 
     for channel in channels {
-        guard let channel = channelFromObject(channel, withClient: client) else { continue }
+        guard let channel = channelFromObject(channel, withClient: client) as? DiscordTextChannel else { continue }
 
         channelDict[channel.id] = channel
     }

--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -94,7 +94,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
     var channelCache = [String: DiscordChannel]()
 
-    private let logType = "DiscordClient"
+    private var logType: String { return "DiscordClient" }
     private let voiceQueue = DispatchQueue(label: "voiceQueue")
 
     // MARK: Initializers

--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -556,6 +556,12 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard let guildId = data["id"] as? String else { return }
         guard let removedGuild = guilds.removeValue(forKey: guildId) else { return }
 
+        if let client = removedGuild.client {
+            for channel in removedGuild.channels.keys {
+                client.channelCache[channel] = nil
+            }
+        }
+
         DefaultDiscordLogger.Logger.verbose("Removed guild: %@", type: logType, args: removedGuild)
 
         delegate?.client(self, didDeleteGuild: removedGuild)

--- a/Sources/SwiftDiscord/DiscordDMChannel.swift
+++ b/Sources/SwiftDiscord/DiscordDMChannel.swift
@@ -16,7 +16,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 /// Represents a direct message channel with another user.
-public struct DiscordDMChannel : DiscordChannel {
+public struct DiscordDMChannel : DiscordTextChannel {
     // MARK: Properties
 
     /// The snowflake id of the channel.
@@ -27,9 +27,6 @@ public struct DiscordDMChannel : DiscordChannel {
 
     /// The user this channel is with.
     public let recipient: DiscordUser
-
-    /// A DiscordDMChannel should always be a direct channel
-    public let type = DiscordChannelType.direct
 
     /// Reference to the client.
     public weak var client: DiscordClient?
@@ -64,7 +61,7 @@ public struct DiscordDMChannel : DiscordChannel {
 }
 
 /// Represents a direct message channel with a group of users.
-public struct DiscordGroupDMChannel : DiscordChannel {
+public struct DiscordGroupDMChannel : DiscordTextChannel {
     // MARK: Properties
 
     /// The snowflake id of the channel.
@@ -75,9 +72,6 @@ public struct DiscordGroupDMChannel : DiscordChannel {
 
     /// The users in this channel.
     public let recipients: [DiscordUser]
-
-    /// A DiscordGroupDMChannel should always be a direct channel
-    public let type = DiscordChannelType.groupDM
 
     /// Reference to the client.
     public weak var client: DiscordClient?

--- a/Sources/SwiftDiscord/DiscordDMChannel.swift
+++ b/Sources/SwiftDiscord/DiscordDMChannel.swift
@@ -23,7 +23,7 @@ public struct DiscordDMChannel : DiscordTextChannel {
     public let id: String
 
     /// Whether this channel is private. Should always be true for DMChannels
-    public let isPrivate = true
+    public var isPrivate: Bool { return true }
 
     /// The user this channel is with.
     public let recipient: DiscordUser
@@ -68,7 +68,7 @@ public struct DiscordGroupDMChannel : DiscordTextChannel {
     public let id: String
 
     /// Whether this channel is private. Should always be true for DMChannels
-    public let isPrivate = true
+    public var isPrivate: Bool { return true }
 
     /// The users in this channel.
     public let recipients: [DiscordUser]

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
@@ -236,7 +236,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getChannel(_ channelId: String, callback: @escaping (DiscordGuildChannel?) -> ()) {
+    public func getChannel(_ channelId: String, callback: @escaping (DiscordChannel?) -> ()) {
         let request = DiscordEndpoint.createRequest(with: token, for: .channel, replacing: ["channel.id": channelId])
         let rateLimiterKey = DiscordRateLimitKey(endpoint: .channel, parameters: ["channel.id": channelId])
 
@@ -247,7 +247,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback(DiscordGuildChannel(guildChannelObject: channel))
+            callback(channelFromObject(channel, withClient: nil))
         })
     }
 
@@ -340,7 +340,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback?(DiscordGuildChannel(guildChannelObject: channel))
+            callback?(guildChannelFromObject(channel))
         })
     }
 

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
@@ -78,7 +78,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback?(DiscordGuildChannel(guildChannelObject: channel))
+            callback?(guildChannelFromObject(channel))
         })
     }
 
@@ -176,7 +176,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback(DiscordGuildChannel.guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
+            callback(guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
         })
     }
 
@@ -344,7 +344,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback?(DiscordGuildChannel.guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
+            callback?(guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
         })
     }
 

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer.swift
@@ -478,12 +478,12 @@ public protocol DiscordEndpointConsumer {
 
         - parameter with: An array of `DiscordPermission` that this bot should have
     */
-    func getBotURL(with permissions: [DiscordPermission]) -> URL?
+    func getBotURL(with permissions: DiscordPermission) -> URL?
 }
 
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
-    public func getBotURL(with permissions: [DiscordPermission]) -> URL? {
+    public func getBotURL(with permissions: DiscordPermission) -> URL? {
         guard let user = self.user else { return nil }
 
         return DiscordOAuthEndpoint.createBotAddURL(for: user, with: permissions)

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer.swift
@@ -101,9 +101,9 @@ public protocol DiscordEndpointConsumer {
         Gets the specified channel.
 
         - parameter channelId: The snowflake id of the channel
-        - parameter callback: The callback function containing an optional `DiscordGuildChannel`
+        - parameter callback: The callback function containing an optional `DiscordChannel`
     */
-    func getChannel(_ channelId: String, callback: @escaping (DiscordGuildChannel?) -> ())
+    func getChannel(_ channelId: String, callback: @escaping (DiscordChannel?) -> ())
 
     /**
         Edits a message

--- a/Sources/SwiftDiscord/DiscordGuild.swift
+++ b/Sources/SwiftDiscord/DiscordGuild.swift
@@ -103,7 +103,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
     public private(set) var verificationLevel: Int
 
     init(guildObject: [String: Any], client: DiscordClient?) {
-        channels = DiscordGuildChannel.guildChannelsFromArray(guildObject.get("channels", or: JSONArray()),
+        channels = guildChannelsFromArray(guildObject.get("channels", or: JSONArray()),
             client: client)
         defaultMessageNotifications = guildObject.get("default_message_notifications", or: -1)
         embedEnabled = guildObject.get("embed_enabled", or: false)

--- a/Sources/SwiftDiscord/DiscordGuildChannel.swift
+++ b/Sources/SwiftDiscord/DiscordGuildChannel.swift
@@ -112,7 +112,7 @@ extension DiscordGuildChannel {
 
         if !workingPermissions.contains(.sendMessages) {
             // If they can't send messages, they automatically lose some permissions
-            workingPermissions.subtract([.sendTTSMessages, .mentionEveryone, .attachFiles])
+            workingPermissions.subtract([.sendTTSMessages, .mentionEveryone, .attachFiles, .embedLinks])
         }
 
         if !workingPermissions.contains(.readMessages) {

--- a/Sources/SwiftDiscord/DiscordGuildMember.swift
+++ b/Sources/SwiftDiscord/DiscordGuildMember.swift
@@ -96,6 +96,17 @@ public struct DiscordGuildMember {
         self.guild = guild
     }
 
+    init(guildId: String, user: DiscordUser, deaf: Bool, mute: Bool, nick: String?, roles: [String], joinedAt: Date, guild: DiscordGuild? = nil) {
+        self.user = user
+        self._deaf = deaf
+        self._mute = mute
+        self._nick = nick
+        self.roleIds = roles
+        self.joinedAt = joinedAt
+        self.guild = guild
+        self.guildId = guildId
+    }
+
     static func guildMembersFromArray(_ guildMembersArray: [[String: Any]], withGuildId guildId: String,
                                       guild: DiscordGuild?)
             -> DiscordLazyDictionary<String, DiscordGuildMember> {

--- a/Sources/SwiftDiscord/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/DiscordMessage.swift
@@ -81,8 +81,8 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     public let tts: Bool
 
     /// The channel that this message originated from. Can return nil if the channel couldn't be found.
-    public var channel: DiscordChannel? {
-        return client?.findChannel(fromId: channelId)
+    public var channel: DiscordTextChannel? {
+        return client?.findChannel(fromId: channelId) as? DiscordTextChannel
     }
 
     let files: [DiscordFileUpload]

--- a/Sources/SwiftDiscord/DiscordOAuth.swift
+++ b/Sources/SwiftDiscord/DiscordOAuth.swift
@@ -79,11 +79,11 @@ public enum DiscordOAuthEndpoint : String {
         - parameter for: The snowflake id of the bot user
         - parameter with: An array of `DiscordPermission` that this bot should have
     */
-    public static func createBotAddURL(for user: DiscordUser, with permissions: [DiscordPermission]) -> URL? {
+    public static func createBotAddURL(for user: DiscordUser, with permissions: DiscordPermission) -> URL? {
         guard user.bot else { return nil }
 
         return DiscordOAuthEndpoint.bot.createURL(getParams: [
-            "permissions": String(permissions.reduce(0, |)),
+            "permissions": permissions.rawValue.description,
             "client_id": user.id
         ])
     }

--- a/Sources/SwiftDiscord/DiscordPermission.swift
+++ b/Sources/SwiftDiscord/DiscordPermission.swift
@@ -16,168 +16,83 @@
 // DEALINGS IN THE SOFTWARE.
 
 /// Represents a Discord Permission. Calculating Permissions involves bitwise operations.
-public enum DiscordPermission : Int {
-    /// User has all permissions.
-    case all = -1
-    /// The none permission. Mathmatical.
-    case none = 0
+public struct DiscordPermission : OptionSet, JSONRepresentable {
+    public let rawValue: Int
+
     /// This user can create invites.
-    case createInstantInvite = 0x00000001
+    public static let createInstantInvite = DiscordPermission(rawValue: 0x00000001)
     /// This user can kick members.
-    case kickMembers = 0x00000002
+    public static let kickMembers = DiscordPermission(rawValue: 0x00000002)
     /// This user can ban members.
-    case banMembers = 0x00000004
+    public static let banMembers = DiscordPermission(rawValue: 0x00000004)
     /// This user is an admin.
-    case administrator = 0x00000008
+    public static let administrator = DiscordPermission(rawValue: 0x00000008)
     /// This user can manage channels.
-    case manageChannels = 0x00000010
+    public static let manageChannels = DiscordPermission(rawValue: 0x00000010)
     /// This user can manage the guild.
-    case manageGuild = 0x00000020
+    public static let manageGuild = DiscordPermission(rawValue: 0x00000020)
     /// This user can add reactions.
-    case addReactions = 0x00000040
+    public static let addReactions = DiscordPermission(rawValue: 0x00000040)
     /// This user can view the audit log.
-    case viewAuditLog = 0x00000080
+    public static let viewAuditLog = DiscordPermission(rawValue: 0x00000080)
     /// This user can read messages.
-    case readMessages = 0x00000400
+    public static let readMessages = DiscordPermission(rawValue: 0x00000400)
     /// This user can send messages.
-    case sendMessages = 0x00000800
+    public static let sendMessages = DiscordPermission(rawValue: 0x00000800)
     /// This user can send tts messages.
-    case sendTTSMessages = 0x00001000
+    public static let sendTTSMessages = DiscordPermission(rawValue: 0x00001000)
     /// This user can manage messages.
-    case manageMessages = 0x00002000
+    public static let manageMessages = DiscordPermission(rawValue: 0x00002000)
     /// This user can embed links.
-    case embedLinks = 0x00004000
+    public static let embedLinks = DiscordPermission(rawValue: 0x00004000)
     /// This user can attach files.
-    case attachFiles = 0x00008000
+    public static let attachFiles = DiscordPermission(rawValue: 0x00008000)
     /// This user read the message history.
-    case readMessageHistory = 0x00010000
+    public static let readMessageHistory = DiscordPermission(rawValue: 0x00010000)
     /// This user can mention everyone.
-    case mentionEveryone = 0x00020000
+    public static let mentionEveryone = DiscordPermission(rawValue: 0x00020000)
     /// This user can can add external emojis.
-    case useExternalEmojis = 0x00040000
+    public static let useExternalEmojis = DiscordPermission(rawValue: 0x00040000)
     /// This user can connect to a voice channel.
-    case connect = 0x00100000
+    public static let connect = DiscordPermission(rawValue: 0x00100000)
     /// This user can speak on a voice channel.
-    case speak = 0x00200000
+    public static let speak = DiscordPermission(rawValue: 0x00200000)
     /// This user can mute members.
-    case muteMembers = 0x00400000
+    public static let muteMembers = DiscordPermission(rawValue: 0x00400000)
     /// This user can deafen members.
-    case deafenMembers = 0x00800000
+    public static let deafenMembers = DiscordPermission(rawValue: 0x00800000)
     /// This user can move members.
-    case moveMembers = 0x01000000
+    public static let moveMembers = DiscordPermission(rawValue: 0x01000000)
     /// This user can use VAD.
-    case useVAD = 0x02000000
+    public static let useVAD = DiscordPermission(rawValue: 0x02000000)
     /// This user can change their nickname.
-    case changeNickname = 0x04000000
+    public static let changeNickname = DiscordPermission(rawValue: 0x04000000)
     /// This user can manage nicknames.
-    case manageNicknames = 0x08000000
+    public static let manageNicknames = DiscordPermission(rawValue: 0x08000000)
     /// This user can manage roles.
-    case manageRoles = 0x10000000
+    public static let manageRoles = DiscordPermission(rawValue: 0x10000000)
     /// This user can manage WebHooks
-    case manageWebhooks = 0x20000000
+    public static let manageWebhooks = DiscordPermission(rawValue: 0x20000000)
     /// This user can manage emojis
-    case manageEmojis = 0x40000000
+    public static let manageEmojis = DiscordPermission(rawValue: 0x40000000)
 
     // MARK: Composite permissions
 
     /// All the channel permissions set to true.
-    case allChannel = 0x33F7FC51
+    public static let allChannel = DiscordPermission(rawValue: 0x33F7FC51)
 
     /// All voice permissions set to true
-    case voice = 0x3F00000
+    public static let voice = DiscordPermission(rawValue: 0x3F00000)
 
-    /**
-        Helper operator for permission math.
-
-        - parameter lhs: a DiscordPermission
-        - parameter rhs: a DiscordPermission
-
-        - returns: the or of the two permissiosn
-    */
-    public static func |(lhs: DiscordPermission, rhs: DiscordPermission) -> Int {
-        return lhs.rawValue | rhs.rawValue
+    /// User has all permissions.
+    public static let all = DiscordPermission(rawValue: -1)
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
     }
 
-    /**
-        Helper operator for permission math.
-
-        - parameter lhs: a DiscordPermission
-        - parameter rhs: a DiscordPermission
-
-        - returns: the and of the two permissiosn
-    */
-    public static func &(lhs: DiscordPermission, rhs: DiscordPermission) -> Int {
-        return lhs.rawValue & rhs.rawValue
-    }
-
-    /**
-        Helper operator for permission math.
-
-        - parameter lhs: an int
-        - parameter rhs: a DiscordPermission
-
-        - returns: the or of the two permissiosn
-    */
-    public static func |(lhs: Int, rhs: DiscordPermission) -> Int {
-        return lhs | rhs.rawValue
-    }
-
-    /**
-        Helper operator for permission math.
-
-        - parameter lhs: an Int
-        - parameter rhs: a DiscordPermission
-
-        - returns: the and of the two permissiosn
-    */
-    public static func &(lhs: Int, rhs: DiscordPermission) -> Int {
-        return lhs & rhs.rawValue
-    }
-
-    /**
-        Helper operator for permission math.
-
-        Ors the two permissions and assigns the result to `lhs`.
-
-        - parameter lhs: a Int
-        - parameter rhs: a DiscordPermission
-
-        - returns: the or of the two permissiosn
-    */
-    public static func |=(lhs: inout Int, rhs: DiscordPermission) {
-        lhs |= rhs.rawValue
-    }
-
-    /**
-        Helper operator for permission math.
-
-        Ands the two permissions and assigns the result to `lhs`.
-
-        - parameter lhs: an Int
-        - parameter rhs: a DiscordPermission
-    */
-    public static func &=(lhs: inout Int, rhs: DiscordPermission) {
-        lhs &= rhs.rawValue
-    }
-
-    /**
-        Determines if an Int and a permission represent the same thing.
-
-        - parameter lhs: an Int
-        - parameter rhs: a DiscordPermission
-    */
-    public static func ==(lhs: Int, rhs: DiscordPermission) -> Bool {
-        return lhs == rhs.rawValue
-    }
-
-    /**
-        Returns the inverse of this permission.
-
-        - parameter rhs: The permission.
-        - returns: The inverse of this permission
-    */
-    public static prefix func ~(rhs: DiscordPermission) -> Int {
-        return ~rhs.rawValue
+    func jsonValue() throws -> JSONRepresentable {
+        return self.rawValue
     }
 }
 
@@ -206,10 +121,10 @@ public struct DiscordPermissionOverwrite : JSONAble {
     public let type: DiscordPermissionOverwriteType
 
     /// The permissions that this overwrite is allowed to use.
-    public var allow: Int
+    public var allow: DiscordPermission
 
     /// The permissions that this overwrite is not allowed to use.
-    public var deny: Int
+    public var deny: DiscordPermission
 
     // MARK: Initializers
 
@@ -221,7 +136,7 @@ public struct DiscordPermissionOverwrite : JSONAble {
         - parameter allow: The permissions allowed
         - parameter deny: The permissions denied
     */
-    public init(id: String, type: DiscordPermissionOverwriteType, allow: Int, deny: Int) {
+    public init(id: String, type: DiscordPermissionOverwriteType, allow: DiscordPermission, deny: DiscordPermission) {
         self.id = id
         self.type = type
         self.allow = allow
@@ -231,8 +146,8 @@ public struct DiscordPermissionOverwrite : JSONAble {
     init(permissionOverwriteObject: [String: Any]) {
         id = permissionOverwriteObject.get("id", or: "")
         type = DiscordPermissionOverwriteType(rawValue: permissionOverwriteObject.get("type", or: "")) ?? .role
-        allow = permissionOverwriteObject.get("allow", or: 0)
-        deny = permissionOverwriteObject.get("deny", or: 0)
+        allow = DiscordPermission(rawValue: permissionOverwriteObject.get("allow", or: 0))
+        deny = DiscordPermission(rawValue: permissionOverwriteObject.get("deny", or: 0))
     }
 
     static func overwritesFromArray(_ permissionOverwritesArray: [[String: Any]]) -> [String: DiscordPermissionOverwrite] {

--- a/Sources/SwiftDiscord/DiscordRole.swift
+++ b/Sources/SwiftDiscord/DiscordRole.swift
@@ -54,6 +54,17 @@ public struct DiscordRole : JSONAble, Equatable {
         position = roleObject.get("position", or: 0)
     }
 
+    init(id: String, color: Int, hoist: Bool, managed: Bool, mentionable: Bool, name: String, permissions: DiscordPermission, position: Int) {
+        self.id = id
+        self.color = color
+        self.hoist = hoist
+        self.managed = managed
+        self.mentionable = mentionable
+        self.name = name
+        self.permissions = permissions
+        self.position = position
+    }
+
     static func rolesFromArray(_ rolesArray: [[String: Any]]) -> [String: DiscordRole] {
         var roles = [String: DiscordRole]()
 

--- a/Sources/SwiftDiscord/DiscordRole.swift
+++ b/Sources/SwiftDiscord/DiscordRole.swift
@@ -38,9 +38,7 @@ public struct DiscordRole : JSONAble, Equatable {
     public var name: String
 
     /// The permissions this role has.
-    ///
-    /// *Bit field*
-    public var permissions: Int
+    public var permissions: DiscordPermission
 
     /// The position of this role.
     public var position: Int
@@ -52,7 +50,7 @@ public struct DiscordRole : JSONAble, Equatable {
         managed = roleObject.get("managed", or: false)
         mentionable = roleObject.get("mentionable", or: false)
         name = roleObject.get("name", or: "")
-        permissions = roleObject.get("permissions", or: 0)
+        permissions = DiscordPermission(rawValue: roleObject.get("permissions", or: 0))
         position = roleObject.get("position", or: 0)
     }
 

--- a/Sources/SwiftDiscord/DiscordUser.swift
+++ b/Sources/SwiftDiscord/DiscordUser.swift
@@ -70,7 +70,7 @@ public protocol DiscordUserActor {
     // MARK: Properties
 
     /// The direct message channels this user is in.
-    var directChannels: [String: DiscordChannel] { get }
+    var directChannels: [String: DiscordTextChannel] { get }
 
     /// The guilds that this user is in.
     var guilds: [String: DiscordGuild] { get }

--- a/Sources/SwiftDiscord/DiscordUserGuild.swift
+++ b/Sources/SwiftDiscord/DiscordUserGuild.swift
@@ -32,14 +32,14 @@ public struct DiscordUserGuild {
     public let owner: Bool
 
     /// Bitwise of the user's enabled/disabled permissions.
-    public let permissions: Int
+    public let permissions: DiscordPermission
 
     init(userGuildObject: [String: Any]) {
         id = userGuildObject.get("id", or: "")
         name = userGuildObject.get("name", or: "")
         icon = userGuildObject.get("icon", or: "")
         owner = userGuildObject.get("owner", or: false)
-        permissions = userGuildObject.get("permissions", or: 0)
+        permissions = DiscordPermission(rawValue: userGuildObject.get("permissions", or: 0))
     }
 
     static func userGuildsFromArray(_ guilds: [[String: Any]]) -> [String: DiscordUserGuild] {

--- a/Sources/SwiftDiscord/DiscordUtils.swift
+++ b/Sources/SwiftDiscord/DiscordUtils.swift
@@ -85,6 +85,7 @@ class DiscordDateFormatter {
 
     private init() {
         RFC3339DateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ"
+        RFC3339DateFormatter.locale = Locale(identifier: "en_US")
     }
 
     static func format(_ string: String) -> Date? {

--- a/Sources/SwiftDiscord/DiscordVoiceEncoder.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceEncoder.swift
@@ -251,7 +251,7 @@ open class DiscordOpusEncoder : DiscordOpusCodeable {
     public let channels: Int
 
     /// The maximum size of a opus packet.
-    public let maxPacketSize = 4000
+    public var maxPacketSize: Int { return 4000 }
 
     /// The sampling rate.
     public let sampleRate: Int

--- a/Sources/SwiftDiscord/DiscordVoiceManager.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceManager.swift
@@ -81,7 +81,7 @@ open class DiscordVoiceManager : DiscordVoiceEngineDelegate, Lockable {
 
     var voiceServerInformations = [String: DiscordVoiceServerInformation]()
 
-    private let logType = "DiscordVoiceManager"
+    private var logType: String { return "DiscordVoiceManager" }
 
     // MARK: Initializers
 

--- a/Tests/SwiftDiscordTests/Fixtures.swift
+++ b/Tests/SwiftDiscordTests/Fixtures.swift
@@ -60,14 +60,26 @@ let testPresence: [String: Any] = [
     "status": "offline"
 ]
 
-let testGuildChannel: [String: Any] = [
-    "id": "guildChannel",
+let testGuildTextChannel: [String: Any] = [
+    "id": "guildTextChannel",
     "guild_id": "testGuild",
     "type": 0,
-    "name": "TestChannel",
+    "name": "TestTextChannel",
     "permission_overwrites": [[String: Any]](),
     "position": 0
 ]
+
+let testGuildVoiceChannel: [String: Any] = [
+    "id": "guildVoiceChannel",
+    "guild_id": "testGuild",
+    "type": 2,
+    "name": "TestVoiceChannel",
+    "is_private": false,
+    "permission_overwrites": [[String: Any]](),
+    "position": 5,
+    "bitrate": 64000
+]
+
 
 let testGuild: [String: Any] = [
     "channels": [[String: Any]](),
@@ -115,7 +127,7 @@ let testEmbed: [String: Any] = [:]
 let testMessage: [String: Any] = [
     "attachments": [testAttachment],
     "author": testUser,
-    "channel_id": testGuildChannel["id"] as! String,
+    "channel_id": testGuildTextChannel["id"] as! String,
     "content": "This is a test message",
     "embeds": [testEmbed],
     "id": "testMessage",
@@ -180,7 +192,7 @@ func createEmojiObjects(n: Int) -> [[String: Any]] {
 let testGuildJSON: [String: Any] = {
     var tGuild = testGuild
 
-    tGuild["channels"] = [testGuildChannel]
+    tGuild["channels"] = [testGuildTextChannel, testGuildVoiceChannel]
     tGuild["members"] = createGuildMemberObjects(n: 20)
     tGuild["presences"] = createPresenceObjects(n: 20)
     tGuild["member_count"] = 20

--- a/Tests/SwiftDiscordTests/TestDiscordClient.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordClient.swift
@@ -97,7 +97,7 @@ class TestDiscordClient : XCTestCase {
         expectations[.guildCreate] = expectation(description: "Client should call guild member remove method")
         expectations[.channelCreate] = expectation(description: "Client should call create create method")
 
-        var tChannel = testGuildChannel
+        var tChannel = testGuildTextChannel
 
         tChannel["id"] = "testChannel2"
         tChannel["name"] = "A new channel"
@@ -129,7 +129,7 @@ class TestDiscordClient : XCTestCase {
         expectations[.channelCreate] = expectation(description: "Client should call channel create method")
         expectations[.channelDelete] = expectation(description: "Client should call delete channel method")
 
-        var tChannel = testGuildChannel
+        var tChannel = testGuildTextChannel
 
         tChannel["id"] = "testChannel2"
         tChannel["name"] = "A new channel"
@@ -165,7 +165,7 @@ class TestDiscordClient : XCTestCase {
         expectations[.guildCreate] = expectation(description: "Client should call guild member remove method")
         expectations[.channelUpdate] = expectation(description: "Client should call update channel method")
 
-        var tChannel = testGuildChannel
+        var tChannel = testGuildTextChannel
 
         tChannel["name"] = "A new channel"
 
@@ -257,12 +257,22 @@ class TestDiscordClient : XCTestCase {
         waitForExpectations(timeout: 0.2)
     }
 
-    func testClientFindsGuildChannel() {
+    func testClientFindsGuildTextChannel() {
         expectations[.guildCreate] = expectation(description: "Client should call guild create method")
 
         client.handleDispatch(event: .guildCreate, data: .object(testGuildJSON))
 
-        assertFindChannel(channelFixture: testGuildChannel, channelType: DiscordGuildChannel.self)
+        assertFindChannel(channelFixture: testGuildTextChannel, channelType: DiscordGuildTextChannel.self)
+
+        waitForExpectations(timeout: 0.2)
+    }
+
+    func testClientFindsGuildVoiceChannel() {
+        expectations[.guildCreate] = expectation(description: "Client should call guild create method")
+
+        client.handleDispatch(event: .guildCreate, data: .object(testGuildJSON))
+
+        assertFindChannel(channelFixture: testGuildVoiceChannel, channelType: DiscordGuildVoiceChannel.self)
 
         waitForExpectations(timeout: 0.2)
     }
@@ -348,7 +358,6 @@ extension TestDiscordClient {
             XCTAssertNil(client.directChannels[channel.id], "Deleted DM Channel should not be in direct channels")
         }
 
-        XCTAssertEqual(channel.type, .direct, "Create channel should correctly type direct channels")
         XCTAssertEqual(channel.id, testUser["id"] as! String, "Channel create should index channels by "
                                                               + "recipient id")
     }
@@ -361,7 +370,6 @@ extension TestDiscordClient {
             XCTAssertNil(client.directChannels[channel.id], "Deleted Group DM Channel should not be in direct channels")
         }
 
-        XCTAssertEqual(channel.type, .groupDM, "Create channel should correctly type direct channels")
         XCTAssertEqual(channel.name, "A Group DM", "Channel create should index channels by recipient id")
     }
 
@@ -383,7 +391,7 @@ extension TestDiscordClient : DiscordClientDelegate {
     func client(_ client: DiscordClient, didCreateChannel channel: DiscordChannel) {
         switch channel {
         case let guildChannel as DiscordGuildChannel:
-            assertGuildChannel(guildChannel, expectedGuildChannels: 2, testType: .create)
+            assertGuildChannel(guildChannel, expectedGuildChannels: 3, testType: .create)
         case let dmChannel as DiscordDMChannel:
             assertDMChannel(dmChannel, testType: .create)
         case let groupDmChannel as DiscordGroupDMChannel:
@@ -398,7 +406,7 @@ extension TestDiscordClient : DiscordClientDelegate {
     func client(_ client: DiscordClient, didDeleteChannel channel: DiscordChannel) {
         switch channel {
         case let guildChannel as DiscordGuildChannel:
-            assertGuildChannel(guildChannel, expectedGuildChannels: 1, testType: .delete)
+            assertGuildChannel(guildChannel, expectedGuildChannels: 2, testType: .delete)
         case let dmChannel as DiscordDMChannel:
             assertDMChannel(dmChannel, testType: .delete)
         case let groupDmChannel as DiscordGroupDMChannel:
@@ -423,7 +431,7 @@ extension TestDiscordClient : DiscordClientDelegate {
             return
         }
 
-        XCTAssertEqual(clientGuild.channels.count, 1, "Guild should only have one channel")
+        XCTAssertEqual(clientGuild.channels.count, 2, "Guild should have two channels")
         XCTAssertEqual(guildChannel.name, "A new channel", "A new channel should have been updated")
 
         expectations[.channelUpdate]?.fulfill()
@@ -477,7 +485,7 @@ extension TestDiscordClient : DiscordClientDelegate {
             return
         }
 
-        XCTAssertEqual(clientGuild.channels.count, 1, "Created guild should have one channel")
+        XCTAssertEqual(clientGuild.channels.count, 2, "Created guild should have two channels")
         XCTAssertEqual(clientGuild.members.count, 20, "Created guild should have 20 members")
         XCTAssertEqual(clientGuild.presences.count, 20, "Created guild should have 20 presences")
         XCTAssert(guild === clientGuild, "Guild on the client should be the same as one passed to handler")

--- a/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
@@ -81,11 +81,8 @@ class TestDiscordPermissions : XCTestCase {
     }
 
     override func tearDown() {
-        for (guildID, channelID) in permissionsTestClient.guilds.flatMap({ guild in guild.value.channels.keys.map { (guild.key, $0) } }) {
-            permissionsTestClient.handleChannelDelete(with: ["id": channelID, "type": 0, "guild_id": guildID])
-        }
-        XCTAssertEqual(permissionsTestClient.channelCache.count, 0, "Removing all channels should clear the channel cache")
         permissionsTestClient.handleGuildDelete(with: permissionsTestGuildJSON)
+        XCTAssertEqual(permissionsTestClient.channelCache.count, 0, "Removing guild should clear its channels from the channel cache")
     }
 
     func testBasicPermissions() {

--- a/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
@@ -1,0 +1,143 @@
+//
+//  Created by TellowKrinkle on 2017/06/22.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftDiscord
+
+let permissionsTestUsers = ["23416345", "32564235", "4359835345", "32499342123", "234234120985"].map({ id -> DiscordUser in
+    var tmp = testUser
+    tmp["id"] = id
+    return DiscordUser(userObject: tmp)
+})
+
+let permissionsTestUserPermissions: DiscordPermission = [.createInstantInvite, .addReactions, .readMessages, .sendMessages, .readMessageHistory, .useExternalEmojis, .connect, .speak, .useVAD, .changeNickname]
+let permissionsTestRoles: [DiscordRole] = [
+    DiscordRole(id: "2349683489545", color: 10181046, hoist: true, managed: false, mentionable: true, name: "Admin", permissions: .administrator, position: 3),
+    DiscordRole(id: "32423425264343", color: 10718666, hoist: true, managed: false, mentionable: true, name: "Mod", permissions: permissionsTestUserPermissions.union([.kickMembers, .manageChannels, .viewAuditLog, .sendTTSMessages, .embedLinks, .attachFiles, .mentionEveryone, .muteMembers, .deafenMembers, .moveMembers, .manageNicknames, .manageRoles]), position: 2),
+    DiscordRole(id: "34634634534564", color: 567526, hoist: true, managed: false, mentionable: true, name: "Test", permissions: permissionsTestUserPermissions, position: 1),
+    DiscordRole(id: "34029736498534", color: 0, hoist: false, managed: false, mentionable: false, name: "Muted", permissions: permissionsTestUserPermissions, position: 0)
+]
+
+class PermissionsTestClientDelegate: DiscordClientDelegate { }
+let permissionsTestClientDelegate = PermissionsTestClientDelegate()
+let permissionsTestClient = DiscordClient(token: "Testing", delegate: permissionsTestClientDelegate)
+
+let permissionsTestGuildJSON = { () -> [String: Any] in
+    var tmp = testGuild
+    tmp["owner_id"] = permissionsTestUsers[0].id
+    tmp["roles"] = try! permissionsTestRoles.jsonValue()
+    return tmp
+}()
+
+let permissionsTestGuild = DiscordGuild(guildObject: permissionsTestGuildJSON, client: permissionsTestClient)
+
+let permissionTestMemberRoles: [[String]] = [
+    [permissionsTestRoles[3].id],
+    [permissionsTestRoles[0].id, permissionsTestRoles[2].id],
+    [permissionsTestRoles[1].id],
+    [permissionsTestRoles[1].id, permissionsTestRoles[2].id],
+    [permissionsTestRoles[2].id, permissionsTestRoles[3].id]
+]
+
+let permissionsTestMembers = zip(permissionsTestUsers, permissionTestMemberRoles).map({ (user, roles) -> DiscordGuildMember in
+    return DiscordGuildMember(guildId: permissionsTestGuild.id, user: user, deaf: false, mute: false, nick: nil, roles: roles, joinedAt: DiscordDateFormatter.format("2017-04-25T20:00:00.000000+00:00")!, guild: permissionsTestGuild)
+})
+
+func createPermissionTestChannel(overwrites: [DiscordPermissionOverwrite]) -> DiscordGuildTextChannel {
+    var channelData = testGuildTextChannel
+    channelData["permission_overwrites"] = try? overwrites.jsonValue()
+    channelData["guild_id"] = permissionsTestGuild.id
+    permissionsTestClient.handleChannelCreate(with: channelData)
+    return permissionsTestClient.findChannel(fromId: channelData["id"] as! String) as! DiscordGuildTextChannel
+}
+
+class TestDiscordPermissions : XCTestCase {
+    let roleOverwrites = [
+        DiscordPermissionOverwrite(id: permissionsTestRoles[3].id, type: .role, allow: [], deny: [.sendMessages, .addReactions]),
+        DiscordPermissionOverwrite(id: permissionsTestRoles[2].id, type: .role, allow: .addReactions, deny: []),
+        DiscordPermissionOverwrite(id: permissionsTestRoles[0].id, type: .role, allow: [], deny: .readMessages),
+        DiscordPermissionOverwrite(id: permissionsTestRoles[1].id, type: .role, allow: [], deny: .addReactions)
+    ]
+
+    let userOverwrites = [
+        DiscordPermissionOverwrite(id: permissionsTestUsers[0].id, type: .member, allow: [], deny: .manageMessages),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[1].id, type: .member, allow: [], deny: .manageWebhooks),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[2].id, type: .member, allow: .addReactions, deny: .manageMessages),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[3].id, type: .member, allow: [], deny: .addReactions),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[4].id, type: .member, allow: [.embedLinks, .sendMessages], deny: [])
+    ]
+
+    let depencencyOverwrites = [
+        DiscordPermissionOverwrite(id: permissionsTestRoles[2].id, type: .role, allow: [], deny: .readMessages),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[4].id, type: .member, allow: [.createInstantInvite, .manageChannels, .addReactions, .sendMessages, .sendTTSMessages, .manageMessages, .embedLinks, .attachFiles, .readMessageHistory, .mentionEveryone, .useExternalEmojis], deny: []),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[3].id, type: .member, allow: .readMessages, deny: []),
+        DiscordPermissionOverwrite(id: permissionsTestUsers[2].id, type: .member, allow: [.sendTTSMessages, .embedLinks, .attachFiles, .mentionEveryone], deny: .sendMessages)
+    ]
+
+    override func setUp() {
+        permissionsTestClient.handleGuildCreate(with: permissionsTestGuildJSON)
+    }
+
+    override func tearDown() {
+        for (guildID, channelID) in permissionsTestClient.guilds.flatMap({ guild in guild.value.channels.keys.map { (guild.key, $0) } }) {
+            permissionsTestClient.handleChannelDelete(with: ["id": channelID, "type": 0, "guild_id": guildID])
+        }
+        XCTAssertEqual(permissionsTestClient.channelCache.count, 0, "Removing all channels should clear the channel cache")
+        permissionsTestClient.handleGuildDelete(with: permissionsTestGuildJSON)
+    }
+
+    func testBasicPermissions() {
+        let channel = createPermissionTestChannel(overwrites: [])
+
+        XCTAssertEqual(channel.permissionOverwrites.count, 0, "There should be no permission overwrites for this test!")
+
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[0], .banMembers), "Owners should be able to do anything")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[1], .manageWebhooks), "Admins should be able to do anything")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[2], .manageRoles), "Users should be able to do things allowed by their roles")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[4], .manageRoles), "Users should not be able to do things not allowed by their roles")
+    }
+
+    func testRoleOverrides() {
+        let channel = createPermissionTestChannel(overwrites: roleOverwrites)
+        
+        XCTAssertEqual(channel.permissionOverwrites.count, roleOverwrites.count, "There should be the same number of permission overwrites in this channel as we put in")
+
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[0], .sendMessages), "Owner should override all permissions")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[1], .readMessages), "Admin role should override all permissions")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[4], .addReactions), "An allow override should go over a deny of the same type")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[3], .addReactions), "An allow override should go over a deny of the same type even if the deny is higher on the list")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[4], .sendMessages), "A role permission deny should be properly applied to a normal user")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[2], .addReactions), "A role permission deny should be properly applied to a normal user")
+    }
+
+    func testUserOverrides() {
+        let channel = createPermissionTestChannel(overwrites: userOverwrites + roleOverwrites)
+
+        XCTAssertEqual(channel.permissionOverwrites.count, roleOverwrites.count + userOverwrites.count, "There should be the same number of permission overwrites in this channel as we put in")
+
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[0], .manageMessages), "Owner should override all permissions")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[1], .manageWebhooks), "Admin role should override all permissions")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[2], .addReactions), "User permissions should override role permissions")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[2], .manageMessages), "A user permission deny should be properly applied to a normal user")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[3], .addReactions), "User permissions should override role permissions that overrode other role permissions")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[4], .embedLinks), "User permissions should be properly applied to a normal user")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[4], .sendMessages), "A user allow should override a role deny")
+    }
+
+    func testOverwritesWithDependencies() {
+        let channel = createPermissionTestChannel(overwrites: depencencyOverwrites)
+
+        XCTAssertEqual(channel.permissionOverwrites.count, depencencyOverwrites.count, "There should be the same number of permission overwrites in this channel as we put in")
+
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[4], .sendMessages), "A user who can't read messages shouldn't be able to send them")
+        XCTAssertEqual(channel.permissions(for: permissionsTestMembers[4]).intersection([.createInstantInvite, .manageChannels, .addReactions, .sendMessages, .sendTTSMessages, .manageMessages, .embedLinks, .attachFiles, .readMessageHistory, .mentionEveryone, .useExternalEmojis]), [], "A user who can't read messages shouldn't be able to do any channel-related things")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[4], .sendTTSMessages), "A user who can't send messages shouldn't be able to send TTS messages")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[3], .sendMessages), "A user who has conflicting read messages permissions where the allow is used shouldn't have dependencies blocked")
+        XCTAssertEqual(channel.permissions(for: permissionsTestMembers[2]).intersection([.sendTTSMessages, .embedLinks, .attachFiles, .mentionEveryone]), [], "A user who can't send messages shouldn't be able to send TTS messages, embed links, attach files, or mention everyone")
+    }
+}
+
+
+


### PR DESCRIPTION
- Separated DiscordChannel protocol into DiscordChannel, DiscordTextChannel, and DiscordGuildChannel protocols so only text channels get methods that work on text channels instead of using a runtime check to silently fail.  If you want to call a DiscordTextChannel method on something that returns a DiscordChannel silently skipping voice channels, use `(channel as? DiscordTextChannel)?.doSomething()`  This also means that channels no longer need a stored DiscordChannelType property.  If you want to know the type of a channel, use `channel is <Specific Channel Type>`.
- Made DiscordPermission an OptionSet so it acts like the rest of the imported Objective-C bitfields.
- Made DateFormatter locale always en_US so dates will still be properly interpreted even if your language is set to Arabic or another language that uses different writing for dates.
- Changed let constants with fixed values into computed properties which saves memory because the value won't be included in every struct/class made.