### PR TITLE
Less string replacement

### DIFF
--- a/Sources/SwiftDiscord/DiscordChannel.swift
+++ b/Sources/SwiftDiscord/DiscordChannel.swift
@@ -66,7 +66,7 @@ public extension DiscordChannel {
     public func delete() {
         guard let client = self.client else { return }
 
-        DefaultDiscordLogger.Logger.log("Deleting channel: %@", type: "DiscordChannel", args: id)
+        DefaultDiscordLogger.Logger.log("Deleting channel: \(id)", type: "DiscordChannel")
 
         client.deleteChannel(id)
     }

--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -181,7 +181,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     */
     public func findChannel(fromId channelId: String) -> DiscordChannel? {
         if let channel = channelCache[channelId] {
-            DefaultDiscordLogger.Logger.debug("Got cached channel %@", type: logType, args: channel)
+            DefaultDiscordLogger.Logger.debug("Got cached channel \(channel)", type: logType)
 
             return channel
         }
@@ -193,14 +193,14 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         } else if let dmChannel = directChannels[channelId] {
             channel = dmChannel
         } else {
-            DefaultDiscordLogger.Logger.debug("Couldn't find channel %@", type: logType, args: channelId)
+            DefaultDiscordLogger.Logger.debug("Couldn't find channel \(channelId)", type: logType)
 
             return nil
         }
 
         channelCache[channel.id] = channel
 
-        DefaultDiscordLogger.Logger.debug("Found channel %@", type: logType, args: channel)
+        DefaultDiscordLogger.Logger.debug("Found channel \(channel)", type: logType)
 
         return channel
     }
@@ -215,8 +215,8 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     */
     open func handleDispatch(event: DiscordDispatchEvent, data: DiscordGatewayPayloadData) {
         guard case let .object(eventData) = data else {
-            DefaultDiscordLogger.Logger.error("Got dispatch event without an object: %@, %@",
-                                              type: "DiscordDispatchEventHandler", args: event, data)
+            DefaultDiscordLogger.Logger.error("Got dispatch event without an object: \(event), \(data)",
+                                              type: "DiscordDispatchEventHandler")
             return
         }
 
@@ -266,7 +266,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
             return
         }
 
-        DefaultDiscordLogger.Logger.log("Joining voice channel: %@", type: self.logType, args: channel)
+        DefaultDiscordLogger.Logger.log("Joining voice channel: \(channel)", type: self.logType)
 
         shardManager.sendPayload(DiscordGatewayPayload(code: .gateway(.voiceStatusUpdate),
                                                        payload: .object(["guild_id": guild.id,
@@ -452,7 +452,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
             break
         }
 
-        DefaultDiscordLogger.Logger.verbose("Created channel: %@", type: logType, args: channel)
+        DefaultDiscordLogger.Logger.verbose("Created channel: \(channel)", type: logType)
 
         delegate?.client(self, didCreateChannel: channel)
     }
@@ -485,7 +485,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         channelCache.removeValue(forKey: channelId)
 
-        DefaultDiscordLogger.Logger.verbose("Removed channel: %@", type: logType, args: removedChannel)
+        DefaultDiscordLogger.Logger.verbose("Removed channel: \(removedChannel)", type: logType)
 
         delegate?.client(self, didDeleteChannel: removedChannel)
     }
@@ -504,7 +504,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let channel = guildChannelFromObject(data, client: self)
 
-        DefaultDiscordLogger.Logger.verbose("Updated channel: %@", type: logType, args: channel)
+        DefaultDiscordLogger.Logger.verbose("Updated channel: \(channel)", type: logType)
 
         guilds[channel.guildId]?.channels[channel.id] = channel
 
@@ -527,7 +527,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let guild = DiscordGuild(guildObject: data, client: self)
 
-        DefaultDiscordLogger.Logger.verbose("Created guild: %@", type: self.logType, args: guild)
+        DefaultDiscordLogger.Logger.verbose("Created guild: \(guild)", type: self.logType)
 
         guilds[guild.id] = guild
 
@@ -536,7 +536,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard fillLargeGuilds && guild.large else { return }
 
         // Fill this guild with users immediately
-        DefaultDiscordLogger.Logger.debug("Fill large guild %@ with all users", type: logType, args: guild.id)
+        DefaultDiscordLogger.Logger.debug("Fill large guild \(guild.id) with all users", type: logType)
 
         requestAllUsers(on: guild.id)
     }
@@ -562,7 +562,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
             }
         }
 
-        DefaultDiscordLogger.Logger.verbose("Removed guild: %@", type: logType, args: removedGuild)
+        DefaultDiscordLogger.Logger.verbose("Removed guild: \(removedGuild)", type: logType)
 
         delegate?.client(self, didDeleteGuild: removedGuild)
     }
@@ -584,7 +584,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let discordEmojis = DiscordEmoji.emojisFromArray(emojis)
 
-        DefaultDiscordLogger.Logger.verbose("Created guild emojis: %@", type: logType, args: discordEmojis)
+        DefaultDiscordLogger.Logger.verbose("Created guild emojis: \(discordEmojis)", type: logType)
 
         guild.emojis = discordEmojis
 
@@ -607,7 +607,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let guildMember = DiscordGuildMember(guildMemberObject: data, guildId: guild.id, guild: guild)
 
-        DefaultDiscordLogger.Logger.verbose("Created guild member: %@", type: logType, args: guildMember)
+        DefaultDiscordLogger.Logger.verbose("Created guild member: \(guildMember)", type: logType)
 
         guild.members[guildMember.user.id] = guildMember
         guild.memberCount += 1
@@ -634,7 +634,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         guard let removedGuildMember = guild.members.removeValue(forKey: id) else { return }
 
-        DefaultDiscordLogger.Logger.verbose("Removed guild member: %@", type: logType, args: removedGuildMember)
+        DefaultDiscordLogger.Logger.verbose("Removed guild member: \(removedGuildMember)", type: logType)
 
         delegate?.client(self, didRemoveGuildMember: removedGuildMember)
     }
@@ -655,7 +655,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard let user = data["user"] as? [String: Any], let id = user["id"] as? String else { return }
         guard let guildMember = guild.members[id]?.updateMember(data) else { return }
 
-        DefaultDiscordLogger.Logger.verbose("Updated guild member: %@", type: logType, args: guildMember)
+        DefaultDiscordLogger.Logger.verbose("Updated guild member: \(guildMember)", type: logType)
 
         delegate?.client(self, didUpdateGuildMember: guildMember)
     }
@@ -698,7 +698,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard let roleObject = data["role"] as? [String: Any] else { return }
         let role = DiscordRole(roleObject: roleObject)
 
-        DefaultDiscordLogger.Logger.verbose("Created role: %@", type: logType, args: role)
+        DefaultDiscordLogger.Logger.verbose("Created role: \(role)", type: logType)
 
         guild.roles[role.id] = role
 
@@ -721,7 +721,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard let roleId = data["role_id"] as? String else { return }
         guard let removedRole = guild.roles.removeValue(forKey: roleId) else { return }
 
-        DefaultDiscordLogger.Logger.verbose("Removed role: %@", type: logType, args: removedRole)
+        DefaultDiscordLogger.Logger.verbose("Removed role: \(removedRole)", type: logType)
 
         delegate?.client(self, didDeleteRole: removedRole, fromGuild: guild)
     }
@@ -743,7 +743,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard let roleObject = data["role"] as? [String: Any] else { return }
         let role = DiscordRole(roleObject: roleObject)
 
-        DefaultDiscordLogger.Logger.verbose("Updated role: %@", type: logType, args: role)
+        DefaultDiscordLogger.Logger.verbose("Updated role: \(role)", type: logType)
 
         guild.roles[role.id] = role
 
@@ -765,7 +765,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         guard let guildId = data["id"] as? String else { return }
         guard let updatedGuild = guilds[guildId]?.updateGuild(fromGuildUpdate: data) else { return }
 
-        DefaultDiscordLogger.Logger.verbose("Updated guild: %@", type: logType, args: updatedGuild)
+        DefaultDiscordLogger.Logger.verbose("Updated guild: \(updatedGuild)", type: logType)
 
         delegate?.client(self, didUpdateGuild: updatedGuild)
     }
@@ -784,7 +784,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let message = DiscordMessage(messageObject: data, client: self)
 
-        DefaultDiscordLogger.Logger.verbose("Message: %@", type: logType, args: message)
+        DefaultDiscordLogger.Logger.verbose("Message: \(message)", type: logType)
 
         delegate?.client(self, didUpdateMessage: message)
     }
@@ -803,7 +803,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let message = DiscordMessage(messageObject: data, client: self)
 
-        DefaultDiscordLogger.Logger.verbose("Message: %@", type: logType, args: message)
+        DefaultDiscordLogger.Logger.verbose("Message: \(message)", type: logType)
 
         delegate?.client(self, didCreateMessage: message)
     }
@@ -830,7 +830,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         }
 
         if !discardPresences {
-            DefaultDiscordLogger.Logger.debug("Updated presence: %@", type: logType, args: presence!)
+            DefaultDiscordLogger.Logger.debug("Updated presence: \(presence!)", type: logType)
 
             guild.presences[userId] = presence!
         }
@@ -884,7 +884,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     */
     open func handleVoiceServerUpdate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling voice server update", type: logType)
-        DefaultDiscordLogger.Logger.verbose("Voice server update: %@", type: logType, args: data)
+        DefaultDiscordLogger.Logger.verbose("Voice server update: \(data)", type: logType)
 
         let info = DiscordVoiceServerInformation(voiceServerInformationObject: data)
 
@@ -909,7 +909,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         let state = DiscordVoiceState(voiceStateObject: data, guildId: guildId)
 
-        DefaultDiscordLogger.Logger.verbose("Voice state: %@", type: logType, args: state)
+        DefaultDiscordLogger.Logger.verbose("Voice state: \(state)", type: logType)
 
         if state.channelId == "" {
             guilds[guildId]?.voiceStates[state.userId] = nil

--- a/Sources/SwiftDiscord/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/DiscordEndpoint.swift
@@ -267,6 +267,90 @@ public enum DiscordEndpoint: CustomStringConvertible {
         }
     }
 
+	internal var endpointForRateLimiter: DiscordEndpoint {
+		switch self {
+		case .baseURL:
+			DefaultDiscordLogger.Logger.error("Attempted to get rate limit key for base URL", type: "DiscordEndpoint")
+			return self
+
+		// -- Channels --
+		case .channel:
+			return self
+		// Messages
+		case .messages:
+			return self
+		case .bulkMessageDelete:
+			return self
+		case let .channelMessage(channel, _):
+			return .messages(channel: channel)
+		case .channelMessageDelete:
+			return self // Special case for the rate limiter
+		case .typing:
+			return self
+		// Permissions
+		case .permissions:
+			return self
+		case let .channelPermission(channel, _):
+			return .permissions(channel: channel)
+		// Invites
+		case .invites:
+			return self
+		case .channelInvites:
+			return self
+		// Pinned Messages
+		case .pins:
+			return self
+		case let .pinnedMessage(channel, _):
+			return .pins(channel: channel)
+		// Webhooks
+		case .channelWebhooks:
+			return self
+
+		// -- Guilds --
+		case .guilds:
+			return self
+		// Guild Channels
+		case .guildChannels:
+			return self
+		// Guild Members
+		case .guildMembers:
+			return self
+		case let .guildMember(guild, _):
+			return .guildMembers(guild: guild)
+		case .guildMemberRole:
+			return self // This is way too specific but there isn't a better one
+		// Guild Bans
+		case .guildBans:
+			return self
+		case let .guildBanUser(guild, _):
+			return .guildBans(guild: guild)
+		// Guild Roles
+		case .guildRoles:
+			return self
+		case let .guildRole(guild, _):
+			return .guildRoles(guild: guild)
+		// Webhooks
+		case .guildWebhooks:
+			return self
+
+		// -- User --
+		case .userChannels:
+			return self
+		case .userGuilds:
+			return self
+
+		// -- Webhooks --
+		case .webhook:
+			return self
+		case let .webhookWithToken(id, _):
+			return .webhook(id: id)
+		case let .webhookSlack(id, _):
+			return .webhook(id: id)
+		case let .webhookGithub(id, _):
+			return .webhook(id: id)
+		}
+	}
+
     // MARK: Methods
 
     /**

--- a/Sources/SwiftDiscord/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/DiscordEndpoint.swift
@@ -186,54 +186,84 @@ public enum DiscordEndpoint: CustomStringConvertible {
 
     public var description: String {
         switch self {
-        case .baseURL: return "https://discordapp.com/api/v6"
+        case .baseURL:
+			return "https://discordapp.com/api/v6"
 
         // -- Channels --
-        case let .channel(id): return "/channels/\(id)"
+        case let .channel(id):
+			return "/channels/\(id)"
         // Messages
-        case let .messages(channel):                return "/channels/\(channel)/messages"
-        case let .bulkMessageDelete(channel):       return "/channels/\(channel)/messages/bulk_delete"
-        case let .channelMessage(channel, message): return "/channels/\(channel)/messages/\(message)"
-        case let .channelMessageDelete(channel, message): return "/channels/\(channel)/messages/\(message)"
-        case let .typing(channel):                  return "/channels/\(channel)/typing"
+        case let .messages(channel):
+			return "/channels/\(channel)/messages"
+        case let .bulkMessageDelete(channel):
+			return "/channels/\(channel)/messages/bulk_delete"
+        case let .channelMessage(channel, message):
+			return "/channels/\(channel)/messages/\(message)"
+        case let .channelMessageDelete(channel, message):
+			return "/channels/\(channel)/messages/\(message)"
+        case let .typing(channel):
+			return "/channels/\(channel)/typing"
         // Permissions
-        case let .permissions(channel):                  return "/channels/\(channel)/permissions"
-        case let .channelPermission(channel, overwrite): return "/channels/\(channel)/permissions/\(overwrite)"
+        case let .permissions(channel):
+			return "/channels/\(channel)/permissions"
+        case let .channelPermission(channel, overwrite):
+			return "/channels/\(channel)/permissions/\(overwrite)"
         // Invites
-        case let .invites(code):           return "/invites/\(code)"
-        case let .channelInvites(channel): return "/channels/\(channel)/invites"
+        case let .invites(code):
+			return "/invites/\(code)"
+        case let .channelInvites(channel):
+			return "/channels/\(channel)/invites"
         // Pinned Messages
-        case let .pins(channel):                   return "/channels/\(channel)/pins"
-        case let .pinnedMessage(channel, message): return "/channels/\(channel)/pins/\(message)"
+        case let .pins(channel):
+			return "/channels/\(channel)/pins"
+        case let .pinnedMessage(channel, message):
+			return "/channels/\(channel)/pins/\(message)"
         // Webhooks
-        case let .channelWebhooks(channel): return "/channels/\(channel)/webhooks"
+        case let .channelWebhooks(channel):
+			return "/channels/\(channel)/webhooks"
 
         // -- Guilds --
-        case let .guilds(id): return "/guilds/\(id)"
+        case let .guilds(id):
+			return "/guilds/\(id)"
         // Guild Channels
-        case let .guildChannels(guild): return "/guilds/\(guild)/channels"
+        case let .guildChannels(guild):
+			return "/guilds/\(guild)/channels"
         // Guild Members
-        case let .guildMembers(guild):                return "/guilds/\(guild)/members"
-        case let .guildMember(guild, user):           return "/guilds/\(guild)/members/\(user)"
-        case let .guildMemberRole(guild, user, role): return "/guilds/\(guild)/members/\(user)/roles/\(role)"
+        case let .guildMembers(guild):
+			return "/guilds/\(guild)/members"
+        case let .guildMember(guild, user):
+			return "/guilds/\(guild)/members/\(user)"
+        case let .guildMemberRole(guild, user, role):
+			return "/guilds/\(guild)/members/\(user)/roles/\(role)"
         // Guild Bans
-        case let .guildBans(guild):          return "/guilds/\(guild)/bans"
-        case let .guildBanUser(guild, user): return "/guilds/\(guild)/bans/\(user)"
+        case let .guildBans(guild):
+			return "/guilds/\(guild)/bans"
+        case let .guildBanUser(guild, user):
+			return "/guilds/\(guild)/bans/\(user)"
         // Guild Roles
-        case let .guildRoles(guild):      return "/guilds/\(guild)/roles"
-        case let .guildRole(guild, role): return "/guilds/\(guild)/roles/\(role)"
+        case let .guildRoles(guild):
+			return "/guilds/\(guild)/roles"
+        case let .guildRole(guild, role):
+			return "/guilds/\(guild)/roles/\(role)"
         // Webhooks
-        case let .guildWebhooks(guild): return "/guilds/\(guild)/webhooks"
+        case let .guildWebhooks(guild):
+			return "/guilds/\(guild)/webhooks"
 
         // -- User --
-        case .userChannels: return "/users/@me/channels"
-        case .userGuilds:   return "/users/@me/guilds"
+        case .userChannels:
+			return "/users/@me/channels"
+        case .userGuilds:
+			return "/users/@me/guilds"
 
         // -- Webhooks --
-        case let .webhook(id):                 return "/webhooks/\(id)"
-        case let .webhookWithToken(id, token): return "/webhooks/\(id)/\(token)"
-        case let .webhookSlack(id, token):     return "/webhooks/\(id)/\(token)/slack"
-        case let .webhookGithub(id, token):    return "/webhooks/\(id)/\(token)/github"
+        case let .webhook(id):
+			return "/webhooks/\(id)"
+        case let .webhookWithToken(id, token):
+			return "/webhooks/\(id)/\(token)"
+        case let .webhookSlack(id, token):
+			return "/webhooks/\(id)/\(token)/slack"
+        case let .webhookGithub(id, token):
+			return "/webhooks/\(id)/\(token)/github"
         }
     }
 
@@ -253,8 +283,7 @@ public enum DiscordEndpoint: CustomStringConvertible {
         let getParams: [String: String]?
         if case let .get(params) = method {
             getParams = params
-        }
-        else {
+        } else {
             getParams = nil
         }
 
@@ -267,17 +296,15 @@ public enum DiscordEndpoint: CustomStringConvertible {
         var content: (Data, type: HTTPContentType)? = nil
         if case let .post(optionalContent) = method {
             content = optionalContent
-        }
-        else if case let .put(optionalContent) = method {
+        } else if case let .put(optionalContent) = method {
             content = optionalContent
-        }
-        else if case let .patch(optionalContent) = method {
+        } else if case let .patch(optionalContent) = method {
             content = optionalContent
         }
         if let content = content {
             request.httpBody = content.0
-            request.setValue(content.type.description, forHTTPHeaderField: "Content-Type")
-            request.setValue(content.0.count.description, forHTTPHeaderField: "Content-Length")
+            request.setValue(String(describing: content.type), forHTTPHeaderField: "Content-Type")
+            request.setValue(String(content.0.count), forHTTPHeaderField: "Content-Length")
         }
 
         return request
@@ -300,8 +327,7 @@ public enum DiscordEndpoint: CustomStringConvertible {
             com.queryItems = getParams.map({ URLQueryItem(name: $0.key, value: $0.value) })
 
             return com.url!
-        }
-        else {
+        } else {
             return url
         }
     }

--- a/Sources/SwiftDiscord/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/DiscordEndpoint.swift
@@ -158,10 +158,10 @@ public enum DiscordEndpoint: CustomStringConvertible {
     /* End Guilds */
 
     /* User */
-    /// The user channels endpoint.  Use nil for self.
+    /// The user channels endpoint.
     case userChannels
 
-    /// The user guilds endpoint.  Use nil for self
+    /// The user guilds endpoint.
     case userGuilds
 
     /* Webhooks */

--- a/Sources/SwiftDiscord/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/DiscordEndpoint.swift
@@ -156,246 +156,243 @@ public enum DiscordEndpoint: CustomStringConvertible {
         return DiscordEndpoint.baseURL.description + description
     }
 
-	// MARK: Endpoint Request enum
+    // MARK: Endpoint Request enum
 
-	/**
-	* An HTTP Request for an Endpoint.  This includes any associated data.
-	*/
-	public enum EndpointRequest {
-		case get(params: [String: String]?)
-		case post(content: (Data, type: HTTPContentType)?)
-		case put(content: (Data, type: HTTPContentType)?)
-		case patch(content: (Data, type: HTTPContentType)?)
-		case delete
+    /**
+    * An HTTP Request for an Endpoint.  This includes any associated data.
+    */
+    public enum EndpointRequest {
+        case get(params: [String: String]?)
+        case post(content: (Data, type: HTTPContentType)?)
+        case put(content: (Data, type: HTTPContentType)?)
+        case patch(content: (Data, type: HTTPContentType)?)
+        case delete
 
-		var methodString: String {
-			switch self {
-			case .get:
-				return "GET"
-			case .post:
-				return "POST"
-			case .put:
-				return "PUT"
-			case .patch:
-				return "PATCH"
-			case .delete:
-				return "DELETE"
-			}
-		}
+        var methodString: String {
+            switch self {
+            case .get:
+                return "GET"
+            case .post:
+                return "POST"
+            case .put:
+                return "PUT"
+            case .patch:
+                return "PATCH"
+            case .delete:
+                return "DELETE"
+            }
+        }
 
-		/**
-		Helper method that creates the basic request for an endpoint.
+        /**
+        Helper method that creates the basic request for an endpoint.
 
-		- parameter with: A DiscordToken that will be used for authentication
-		- parameter for: The endpoint this request is for
-		- parameter getParams: An optional dictionary of get parameters.
+        - parameter with: A DiscordToken that will be used for authentication
+        - parameter for: The endpoint this request is for
+        - parameter getParams: An optional dictionary of get parameters.
 
-		- returns: a URLRequest that can be further customized
-		*/
-		public func createRequest(with token: DiscordToken, endpoint: DiscordEndpoint) -> URLRequest? {
+        - returns: a URLRequest that can be further customized
+        */
+        public func createRequest(with token: DiscordToken, endpoint: DiscordEndpoint) -> URLRequest? {
 
-			let getParams: [String: String]?
-			if case let .get(params) = self {
-				getParams = params
-			}
-			else {
-				getParams = nil
-			}
+            let getParams: [String: String]?
+            if case let .get(params) = self {
+                getParams = params
+            } else {
+                getParams = nil
+            }
 
-			guard let url = endpoint.createURL(getParams: getParams) else { return nil }
-			var request = URLRequest(url: url)
+            guard let url = endpoint.createURL(getParams: getParams) else { return nil }
+            var request = URLRequest(url: url)
 
-			request.setValue(token.token, forHTTPHeaderField: "Authorization")
-			request.httpMethod = self.methodString
+            request.setValue(token.token, forHTTPHeaderField: "Authorization")
+            request.httpMethod = self.methodString
 
-			var content: (Data, type: HTTPContentType)? = nil
-			if case let .post(optionalContent) = self {
-				content = optionalContent
-			}
-			else if case let .put(optionalContent) = self {
-				content = optionalContent
-			}
-			else if case let .patch(optionalContent) = self {
-				content = optionalContent
-			}
-			if let content = content {
-				request.httpBody = content.0
-				request.setValue(content.type.description, forHTTPHeaderField: "Content-Type")
-				request.setValue(content.0.count.description, forHTTPHeaderField: "Content-Length")
-			}
+            var content: (Data, type: HTTPContentType)? = nil
+            if case let .post(optionalContent) = self {
+                content = optionalContent
+            } else if case let .put(optionalContent) = self {
+                content = optionalContent
+            } else if case let .patch(optionalContent) = self {
+                content = optionalContent
+            }
+            if let content = content {
+                request.httpBody = content.0
+                request.setValue(content.type.description, forHTTPHeaderField: "Content-Type")
+                request.setValue(content.0.count.description, forHTTPHeaderField: "Content-Length")
+            }
 
-			return request
-		}
-	}
+            return request
+        }
+    }
 
     // MARK: Endpoint string calculation
 
     public var description: String {
         switch self {
         case .baseURL:
-			return "https://discordapp.com/api/v6"
+            return "https://discordapp.com/api/v6"
 
         // -- Channels --
         case let .channel(id):
-			return "/channels/\(id)"
+            return "/channels/\(id)"
         // Messages
         case let .messages(channel):
-			return "/channels/\(channel)/messages"
+            return "/channels/\(channel)/messages"
         case let .bulkMessageDelete(channel):
-			return "/channels/\(channel)/messages/bulk_delete"
+            return "/channels/\(channel)/messages/bulk_delete"
         case let .channelMessage(channel, message):
-			return "/channels/\(channel)/messages/\(message)"
+            return "/channels/\(channel)/messages/\(message)"
         case let .channelMessageDelete(channel, message):
-			return "/channels/\(channel)/messages/\(message)"
+            return "/channels/\(channel)/messages/\(message)"
         case let .typing(channel):
-			return "/channels/\(channel)/typing"
+            return "/channels/\(channel)/typing"
         // Permissions
         case let .permissions(channel):
-			return "/channels/\(channel)/permissions"
+            return "/channels/\(channel)/permissions"
         case let .channelPermission(channel, overwrite):
-			return "/channels/\(channel)/permissions/\(overwrite)"
+            return "/channels/\(channel)/permissions/\(overwrite)"
         // Invites
         case let .invites(code):
-			return "/invites/\(code)"
+            return "/invites/\(code)"
         case let .channelInvites(channel):
-			return "/channels/\(channel)/invites"
+            return "/channels/\(channel)/invites"
         // Pinned Messages
         case let .pins(channel):
-			return "/channels/\(channel)/pins"
+            return "/channels/\(channel)/pins"
         case let .pinnedMessage(channel, message):
-			return "/channels/\(channel)/pins/\(message)"
+            return "/channels/\(channel)/pins/\(message)"
         // Webhooks
         case let .channelWebhooks(channel):
-			return "/channels/\(channel)/webhooks"
+            return "/channels/\(channel)/webhooks"
 
         // -- Guilds --
         case let .guilds(id):
-			return "/guilds/\(id)"
+            return "/guilds/\(id)"
         // Guild Channels
         case let .guildChannels(guild):
-			return "/guilds/\(guild)/channels"
+            return "/guilds/\(guild)/channels"
         // Guild Members
         case let .guildMembers(guild):
-			return "/guilds/\(guild)/members"
+            return "/guilds/\(guild)/members"
         case let .guildMember(guild, user):
-			return "/guilds/\(guild)/members/\(user)"
+            return "/guilds/\(guild)/members/\(user)"
         case let .guildMemberRole(guild, user, role):
-			return "/guilds/\(guild)/members/\(user)/roles/\(role)"
+            return "/guilds/\(guild)/members/\(user)/roles/\(role)"
         // Guild Bans
         case let .guildBans(guild):
-			return "/guilds/\(guild)/bans"
+            return "/guilds/\(guild)/bans"
         case let .guildBanUser(guild, user):
-			return "/guilds/\(guild)/bans/\(user)"
+            return "/guilds/\(guild)/bans/\(user)"
         // Guild Roles
         case let .guildRoles(guild):
-			return "/guilds/\(guild)/roles"
+            return "/guilds/\(guild)/roles"
         case let .guildRole(guild, role):
-			return "/guilds/\(guild)/roles/\(role)"
+            return "/guilds/\(guild)/roles/\(role)"
         // Webhooks
         case let .guildWebhooks(guild):
-			return "/guilds/\(guild)/webhooks"
+            return "/guilds/\(guild)/webhooks"
 
         // -- User --
         case .userChannels:
-			return "/users/@me/channels"
+            return "/users/@me/channels"
         case .userGuilds:
-			return "/users/@me/guilds"
+            return "/users/@me/guilds"
 
         // -- Webhooks --
         case let .webhook(id):
-			return "/webhooks/\(id)"
+            return "/webhooks/\(id)"
         case let .webhookWithToken(id, token):
-			return "/webhooks/\(id)/\(token)"
+            return "/webhooks/\(id)/\(token)"
         case let .webhookSlack(id, token):
-			return "/webhooks/\(id)/\(token)/slack"
+            return "/webhooks/\(id)/\(token)/slack"
         case let .webhookGithub(id, token):
-			return "/webhooks/\(id)/\(token)/github"
+            return "/webhooks/\(id)/\(token)/github"
         }
     }
 
-	internal var endpointForRateLimiter: DiscordEndpoint {
-		switch self {
-		case .baseURL:
-			DefaultDiscordLogger.Logger.error("Attempted to get rate limit key for base URL", type: "DiscordEndpoint")
-			return self
+    internal var endpointForRateLimiter: DiscordEndpoint {
+        switch self {
+        case .baseURL:
+            DefaultDiscordLogger.Logger.error("Attempted to get rate limit key for base URL", type: "DiscordEndpoint")
+            return self
 
-		// -- Channels --
-		case .channel:
-			return self
-		// Messages
-		case .messages:
-			return self
-		case .bulkMessageDelete:
-			return self
-		case let .channelMessage(channel, _):
-			return .messages(channel: channel)
-		case .channelMessageDelete:
-			return self // Special case for the rate limiter
-		case .typing:
-			return self
-		// Permissions
-		case .permissions:
-			return self
-		case let .channelPermission(channel, _):
-			return .permissions(channel: channel)
-		// Invites
-		case .invites:
-			return self
-		case .channelInvites:
-			return self
-		// Pinned Messages
-		case .pins:
-			return self
-		case let .pinnedMessage(channel, _):
-			return .pins(channel: channel)
-		// Webhooks
-		case .channelWebhooks:
-			return self
+        // -- Channels --
+        case .channel:
+            return self
+        // Messages
+        case .messages:
+            return self
+        case .bulkMessageDelete:
+            return self
+        case let .channelMessage(channel, _):
+            return .messages(channel: channel)
+        case .channelMessageDelete:
+            return self // Special case for the rate limiter
+        case .typing:
+            return self
+        // Permissions
+        case .permissions:
+            return self
+        case let .channelPermission(channel, _):
+            return .permissions(channel: channel)
+        // Invites
+        case .invites:
+            return self
+        case .channelInvites:
+            return self
+        // Pinned Messages
+        case .pins:
+            return self
+        case let .pinnedMessage(channel, _):
+            return .pins(channel: channel)
+        // Webhooks
+        case .channelWebhooks:
+            return self
 
-		// -- Guilds --
-		case .guilds:
-			return self
-		// Guild Channels
-		case .guildChannels:
-			return self
-		// Guild Members
-		case .guildMembers:
-			return self
-		case let .guildMember(guild, _):
-			return .guildMembers(guild: guild)
-		case .guildMemberRole:
-			return self // This is way too specific but there isn't a better one
-		// Guild Bans
-		case .guildBans:
-			return self
-		case let .guildBanUser(guild, _):
-			return .guildBans(guild: guild)
-		// Guild Roles
-		case .guildRoles:
-			return self
-		case let .guildRole(guild, _):
-			return .guildRoles(guild: guild)
-		// Webhooks
-		case .guildWebhooks:
-			return self
+        // -- Guilds --
+        case .guilds:
+            return self
+        // Guild Channels
+        case .guildChannels:
+            return self
+        // Guild Members
+        case .guildMembers:
+            return self
+        case let .guildMember(guild, _):
+            return .guildMembers(guild: guild)
+        case .guildMemberRole:
+            return self // This is way too specific but there isn't a better one
+        // Guild Bans
+        case .guildBans:
+            return self
+        case let .guildBanUser(guild, _):
+            return .guildBans(guild: guild)
+        // Guild Roles
+        case .guildRoles:
+            return self
+        case let .guildRole(guild, _):
+            return .guildRoles(guild: guild)
+        // Webhooks
+        case .guildWebhooks:
+            return self
 
-		// -- User --
-		case .userChannels:
-			return self
-		case .userGuilds:
-			return self
+        // -- User --
+        case .userChannels:
+            return self
+        case .userGuilds:
+            return self
 
-		// -- Webhooks --
-		case .webhook:
-			return self
-		case let .webhookWithToken(id, _):
-			return .webhook(id: id)
-		case let .webhookSlack(id, _):
-			return .webhook(id: id)
-		case let .webhookGithub(id, _):
-			return .webhook(id: id)
-		}
-	}
+        // -- Webhooks --
+        case .webhook:
+            return self
+        case let .webhookWithToken(id, _):
+            return .webhook(id: id)
+        case let .webhookSlack(id, _):
+            return .webhook(id: id)
+        case let .webhookGithub(id, _):
+            return .webhook(id: id)
+        }
+    }
 
     // MARK: Methods
 

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
@@ -349,8 +349,8 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                             callback: ((DiscordMessage?) -> ())? = nil) {
         var request = DiscordEndpoint.createRequest(with: token, for: .messages, replacing: ["channel.id": channelId])
 
-        DefaultDiscordLogger.Logger.log("Sending message to: %@", type: "DiscordEndpointChannels", args: channelId)
-        DefaultDiscordLogger.Logger.verbose("Message: %@", type: "DiscordEndpointChannels", args: message)
+        DefaultDiscordLogger.Logger.log("Sending message to: \(channelId)", type: "DiscordEndpointChannels")
+        DefaultDiscordLogger.Logger.verbose("Message: \(message)", type: "DiscordEndpointChannels")
 
         request.httpMethod = "POST"
 

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
@@ -20,42 +20,19 @@ import Foundation
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
     public func addPinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .pinnedMessage, replacing: [
-            "channel.id": channelId,
-            "message.id": messageId
-        ])
-
-        request.httpMethod = "PUT"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .pins, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .pinnedMessage(channel: channelId, message: messageId),
+                                   token: token,
+                                   method: .put(content: nil),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
     public func bulkDeleteMessages(_ messages: [String], on channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .bulkMessageDelete, replacing: [
-            "channel.id": channelId
-        ])
-
-        let editObject = [
-            "messages": messages
-        ]
-
-        guard let contentData = JSON.encodeJSONData(editObject) else { return }
-
-        request.httpMethod = "POST"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .messages, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        guard let contentData = JSON.encodeJSONData(["messages": messages]) else { return }
+        rateLimiter.executeRequest(endpoint: .bulkMessageDelete(channel: channelId),
+                                   token: token,
+                                   method: .post(content: (contentData, type: .json)),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
@@ -78,89 +55,51 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         guard let contentData = JSON.encodeJSONData(inviteJSON) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .channelInvites, replacing: [
-            "channel.id": channelId
-        ])
-
-        request.httpMethod = "POST"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .channelInvites, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(invite)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
 
                 return
             }
-
             callback(DiscordInvite(inviteObject: invite))
-        })
+        }
+
+        rateLimiter.executeRequest(endpoint: .channelInvites(channel: channelId),
+                                   token: token,
+                                   method: .post(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func deleteChannel(_ channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .channel, replacing: [
-            "channel.id": channelId,
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .channel, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 200)
-        })
+        rateLimiter.executeRequest(endpoint: .channel(id: channelId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: { _, response, _ in callback?(response?.statusCode == 200) })
     }
 
     /// Default implementation
     public func deleteChannelPermission(_ overwriteId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .channelPermission, replacing: [
-            "channel.id": channelId,
-            "overwrite.id": overwriteId
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .permissions, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .channelPermission(channel: channelId, overwrite: overwriteId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
     public func deleteMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .channelMessage, replacing: [
-            "channel.id": channelId,
-            "message.id": messageId
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .messages, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .channelMessageDelete(channel: channelId, message: messageId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
     public func deletePinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .pinnedMessage, replacing: [
-            "channel.id": channelId,
-            "message.id": messageId
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .pins, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .pinnedMessage(channel: channelId, message: messageId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
@@ -168,87 +107,60 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                       callback: ((Bool) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(permissionOverwrite.json) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .channelPermission, replacing: [
-            "channel.id": channelId,
-            "overwrite.id": permissionOverwrite.id
-        ])
-
-        request.httpMethod = "PUT"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .permissions, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .channelPermission(channel: channelId, overwrite: permissionOverwrite.id),
+                                   token: token,
+                                   method: .put(content: (contentData, type: .json)),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
     public func getInvites(for channelId: String, callback: @escaping ([DiscordInvite]) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .channelInvites, replacing: [
-            "channel.id": channelId
-        ])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .channelInvites, parameters: ["channel.id": channelId])
 
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(invites)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             callback(DiscordInvite.invitesFromArray(inviteArray: invites as! [[String: Any]]))
-        })
+        }
+
+        rateLimiter.executeRequest(endpoint: .channelInvites(channel: channelId),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func editMessage(_ messageId: String, on channelId: String, content: String,
                             callback: ((DiscordMessage?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .channelMessage, replacing: [
-            "channel.id": channelId,
-            "message.id": messageId
-        ])
+        guard let contentData = JSON.encodeJSONData(["content": content]) else { return }
 
-        let editObject = [
-            "content": content
-        ]
-
-        guard let contentData = JSON.encodeJSONData(editObject) else { return }
-
-        request.httpMethod = "PATCH"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .messages, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(message)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(DiscordMessage(messageObject: message, client: nil))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .channelMessage(channel: channelId, message: messageId),
+                                   token: token,
+                                   method: .patch(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getChannel(_ channelId: String, callback: @escaping (DiscordChannel?) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .channel, replacing: ["channel.id": channelId])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .channel, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .object(channel)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
-
                 return
             }
-
             callback(channelFromObject(channel, withClient: nil))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .channel(id: channelId),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -269,35 +181,32 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        let request = DiscordEndpoint.createRequest(with: token, for: .messages, replacing: ["channel.id": channelId],
-                                                    getParams: getParams)
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .messages, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .array(messages)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             callback(DiscordMessage.messagesFromArray(messages as! [[String: Any]]))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .messages(channel: channelId),
+                                   token: token,
+                                   method: .get(params: getParams),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getPinnedMessages(for channelId: String, callback: @escaping ([DiscordMessage]) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .pins, replacing: ["channel.id": channelId])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .pins, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .array(messages)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             callback(DiscordMessage.messagesFromArray(messages as! [[String: Any]]))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .pins(channel: channelId),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -322,72 +231,50 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         guard let contentData = JSON.encodeJSONData(modifyJSON) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .channel, replacing: [
-            "channel.id": channelId
-        ])
-
-        request.httpMethod = "PATCH"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .channel, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .object(channel)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(guildChannelFromObject(channel))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .channel(id: channelId),
+                                   token: token,
+                                   method: .patch(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation.
     public func sendMessage(_ message: DiscordMessage, to channelId: String,
                             callback: ((DiscordMessage?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .messages, replacing: ["channel.id": channelId])
-
+        let method: HTTPMethod
+        switch message.createDataForSending() {
+        case let .left(data):
+            method = .post(content: (data, type: .json))
+        case let .right((boundary, body)):
+            method = .post(content: (body, type: .other("multipart/form-data; boundary=\(boundary)")))
+        }
         DefaultDiscordLogger.Logger.log("Sending message to: \(channelId)", type: "DiscordEndpointChannels")
         DefaultDiscordLogger.Logger.verbose("Message: \(message)", type: "DiscordEndpointChannels")
 
-        request.httpMethod = "POST"
-
-        switch message.createDataForSending() {
-        case let .left(data):
-            request.httpBody = data
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue(String(data.count), forHTTPHeaderField: "Content-Length")
-        case let .right((boundary, body)):
-            request.httpBody = body
-            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-            request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
-        }
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .messages, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(message)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(DiscordMessage(messageObject: message, client: nil))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .messages(channel: channelId),
+                                   token: token,
+                                   method: method,
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func triggerTyping(on channelId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .typing, replacing: ["channel.id": channelId])
-
-        request.httpMethod = "POST"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .typing, parameters: ["channel.id": channelId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .typing(channel: channelId),
+                                   token: token,
+                                   method: .post(content: nil),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
@@ -22,7 +22,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func addPinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .pinnedMessage(channel: channelId, message: messageId),
                                    token: token,
-                                   method: .put(content: nil),
+                                   requestInfo: .put(content: nil),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -31,7 +31,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         guard let contentData = JSON.encodeJSONData(["messages": messages]) else { return }
         rateLimiter.executeRequest(endpoint: .bulkMessageDelete(channel: channelId),
                                    token: token,
-                                   method: .post(content: (contentData, type: .json)),
+                                   requestInfo: .post(content: (contentData, type: .json)),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -66,7 +66,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         rateLimiter.executeRequest(endpoint: .channelInvites(channel: channelId),
                                    token: token,
-                                   method: .post(content: (contentData, type: .json)),
+                                   requestInfo: .post(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -74,7 +74,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func deleteChannel(_ channelId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .channel(id: channelId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 200) })
     }
 
@@ -82,7 +82,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func deleteChannelPermission(_ overwriteId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .channelPermission(channel: channelId, overwrite: overwriteId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -90,7 +90,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func deleteMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .channelMessageDelete(channel: channelId, message: messageId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -98,7 +98,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func deletePinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .pinnedMessage(channel: channelId, message: messageId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -109,7 +109,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         rateLimiter.executeRequest(endpoint: .channelPermission(channel: channelId, overwrite: permissionOverwrite.id),
                                    token: token,
-                                   method: .put(content: (contentData, type: .json)),
+                                   requestInfo: .put(content: (contentData, type: .json)),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -126,7 +126,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         rateLimiter.executeRequest(endpoint: .channelInvites(channel: channelId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -144,7 +144,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .channelMessage(channel: channelId, message: messageId),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -159,7 +159,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .channel(id: channelId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -190,7 +190,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .messages(channel: channelId),
                                    token: token,
-                                   method: .get(params: getParams),
+                                   requestInfo: .get(params: getParams),
                                    callback: requestCallback)
     }
 
@@ -205,7 +205,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .pins(channel: channelId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -240,19 +240,19 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .channel(id: channelId),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
     /// Default implementation.
     public func sendMessage(_ message: DiscordMessage, to channelId: String,
                             callback: ((DiscordMessage?) -> ())? = nil) {
-        let method: HTTPMethod
+        let requestInfo: DiscordEndpoint.EndpointRequest
         switch message.createDataForSending() {
         case let .left(data):
-            method = .post(content: (data, type: .json))
+            requestInfo = .post(content: (data, type: .json))
         case let .right((boundary, body)):
-            method = .post(content: (body, type: .other("multipart/form-data; boundary=\(boundary)")))
+            requestInfo = .post(content: (body, type: .other("multipart/form-data; boundary=\(boundary)")))
         }
         DefaultDiscordLogger.Logger.log("Sending message to: \(channelId)", type: "DiscordEndpointChannels")
         DefaultDiscordLogger.Logger.verbose("Message: \(message)", type: "DiscordEndpointChannels")
@@ -266,7 +266,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .messages(channel: channelId),
                                    token: token,
-                                   method: method,
+                                   requestInfo: requestInfo,
                                    callback: requestCallback)
     }
 
@@ -274,7 +274,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func triggerTyping(on channelId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .typing(channel: channelId),
                                    token: token,
-                                   method: .post(content: nil),
+                                   requestInfo: .post(content: nil),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
@@ -67,7 +67,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
 
-        DefaultDiscordLogger.Logger.log("Creating guild channel on %@", type: "DiscordEndpointGuild", args: guildId)
+        DefaultDiscordLogger.Logger.log("Creating guild channel on \(guildId)", type: "DiscordEndpointGuild")
 
         let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildChannels, parameters: ["guild.id": guildId])
 
@@ -102,8 +102,8 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        DefaultDiscordLogger.Logger.log("Creating a new role on %@", type: "DiscordEndpointGuild", args: guildId)
-        DefaultDiscordLogger.Logger.verbose("Role options %@", type: "DiscordEndpointGuild", args: roleData)
+        DefaultDiscordLogger.Logger.log("Creating a new role on \(guildId)", type: "DiscordEndpointGuild")
+        DefaultDiscordLogger.Logger.verbose("Role options \(roleData)", type: "DiscordEndpointGuild")
 
         guard let contentData = JSON.encodeJSONData(roleData) else { return callback(nil) }
 
@@ -158,7 +158,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            DefaultDiscordLogger.Logger.debug("Got guild bans %@", type: "DiscordEndpointGuild", args: bans)
+            DefaultDiscordLogger.Logger.debug("Got guild bans \(bans)", type: "DiscordEndpointGuild")
 
             callback(DiscordBan.bansFromArray(bans as! [[String: Any]]))
         })
@@ -363,9 +363,8 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        DefaultDiscordLogger.Logger.debug("Modifying guild member %@ with options: %@ on %@",
-                                          type: "DiscordEndpointGuild",
-                                          args: id, patchParams, guildId)
+        DefaultDiscordLogger.Logger.debug("Modifying guild member \(id) with options: \(patchParams) on \(guildId)",
+                                          type: "DiscordEndpointGuild")
 
         guard let contentData = JSON.encodeJSONData(patchParams) else { return }
 
@@ -422,7 +421,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         request.httpMethod = "DELETE"
 
-        DefaultDiscordLogger.Logger.log("Unbanning %@ on %@", type: "DiscordEndpointGuild", args: userId, guildId)
+        DefaultDiscordLogger.Logger.log("Unbanning \(userId) on \(guildId)", type: "DiscordEndpointGuild")
 
         let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildBans, parameters: ["guild.id": guildId])
 

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
@@ -21,19 +21,10 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
     public func addGuildMemberRole(_ roleId: String, to userId: String, on guildId: String,
                                    callback: ((Bool) -> ())?) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildMemberRole, replacing: [
-            "guild.id": guildId,
-            "user.id": userId,
-            "role.id": roleId
-        ])
-
-        request.httpMethod = "PUT"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildMemberRole, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .guildMemberRole(guild: guildId, user: userId, role: roleId),
+                                   token: token,
+                                   method: .put(content: nil),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
@@ -58,20 +49,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         guard let contentData = JSON.encodeJSONData(createJSON) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildChannels, replacing: [
-            "guild.id": guildId
-        ])
-
-        request.httpMethod = "POST"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        DefaultDiscordLogger.Logger.log("Creating guild channel on \(guildId)", type: "DiscordEndpointGuild")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildChannels, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(channel)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
 
@@ -79,7 +57,11 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
 
             callback?(guildChannelFromObject(channel))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
+                                   token: token,
+                                   method: .post(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -107,14 +89,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         guard let contentData = JSON.encodeJSONData(roleData) else { return callback(nil) }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildRoles, replacing: ["guild.id": guildId])
-
-        request.httpMethod = "POST"
-        request.httpBody = contentData
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildRoles, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(role)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
 
@@ -122,20 +97,16 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
 
             callback(DiscordRole(roleObject: role))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildRoles(guild: guildId),
+                                   token: token,
+                                   method: .post(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func deleteGuild(_ guildId: String, callback: ((DiscordGuild?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .guilds, replacing: [
-            "guild.id": guildId,
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guilds, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(guild)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
 
@@ -143,60 +114,57 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
 
             callback?(DiscordGuild(guildObject: guild, client: nil))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guilds(id: guildId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getGuildBans(for guildId: String, callback: @escaping ([DiscordBan]) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .guildBans, replacing: ["guild.id": guildId])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildBans, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(bans)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             DefaultDiscordLogger.Logger.debug("Got guild bans \(bans)", type: "DiscordEndpointGuild")
-
             callback(DiscordBan.bansFromArray(bans as! [[String: Any]]))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildBans(guild: guildId),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getGuildChannels(_ guildId: String, callback: @escaping ([DiscordGuildChannel]) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .guildChannels, replacing: ["guild.id": guildId])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildChannels, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(channels)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             callback(guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getGuildMember(by id: String, on guildId: String, callback: @escaping (DiscordGuildMember?) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .guildMember, replacing: [
-            "guild.id": guildId,
-            "user.id": id
-        ])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildMembers, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(member)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
-
                 return
             }
-
             callback(DiscordGuildMember(guildMemberObject: member, guildId: guildId))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildMember(guild: guildId, user: id),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -213,38 +181,34 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        let request = DiscordEndpoint.createRequest(with: token, for: .guildMembers, replacing: ["guild.id": guildId],
-                                                    getParams: getParams)
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildMembers, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(members)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             let guildMembers = DiscordGuildMember.guildMembersFromArray(members as! [[String: Any]],
                                                                         withGuildId: guildId, guild: nil)
-
             callback(guildMembers.map({ $0.1 }))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildMembers(guild: guildId),
+                                   token: token,
+                                   method: .get(params: getParams),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getGuildRoles(for guildId: String, callback: @escaping ([DiscordRole]) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .guildRoles, replacing: ["guild.id": guildId])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildRoles, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(roles)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
-
                 return
             }
-
             callback(DiscordRole.rolesFromArray(roles as! [[String: Any]]).map({ $0.value }))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildRoles(guild: guildId),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -252,22 +216,11 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                          callback: ((Bool) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(["delete-message-days": deleteMessageDays]) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildBanUser, replacing: [
-            "guild.id": guildId,
-            "user.id": userId
-        ])
-
-        request.httpMethod = "PUT"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildBans, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
-    }
+        rateLimiter.executeRequest(endpoint: .guildBanUser(guild: guildId, user: userId),
+                                   token: token,
+                                   method: .put(content: (contentData, .json)),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
+        }
 
     /// Default implementation
     public func modifyGuild(_ guildId: String, options: [DiscordEndpoint.Options.ModifyGuild],
@@ -299,18 +252,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         guard let contentData = JSON.encodeJSONData(modifyJSON) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .guilds, replacing: [
-            "guild.id": guildId
-        ])
-
-        request.httpMethod = "PATCH"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guilds, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(guild)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
 
@@ -318,7 +260,11 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
 
             callback?(DiscordGuild(guildObject: guild, client: nil))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guilds(id: guildId),
+                                   token: token,
+                                   method: .patch(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -326,18 +272,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                             callback: (([DiscordGuildChannel]) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(channelPositions) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildChannels, replacing: [
-            "guild.id": guildId
-        ])
-
-        request.httpMethod = "PATCH"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildChannels, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(channels)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?([])
 
@@ -345,7 +280,11 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
 
             callback?(guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
+                                   token: token,
+                                   method: .patch(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
@@ -363,110 +302,65 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
+        guard let contentData = JSON.encodeJSONData(patchParams) else { return }
+
         DefaultDiscordLogger.Logger.debug("Modifying guild member \(id) with options: \(patchParams) on \(guildId)",
                                           type: "DiscordEndpointGuild")
 
-        guard let contentData = JSON.encodeJSONData(patchParams) else { return }
-
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildMember, replacing: [
-            "guild.id": guildId,
-            "user.id": id
-        ])
-
-        request.httpMethod = "PATCH"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildMembers, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .guildMember(guild: guildId, user: id),
+                                   token: token,
+                                   method: .patch(content: (contentData, type: .json)),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
     public func modifyGuildRole(_ role: DiscordRole, on guildId: String, callback: ((DiscordRole?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildRole, replacing: [
-            "guild.id": guildId,
-            "role.id": role.id
-        ])
-
         guard let contentData = JSON.encodeJSONData(role.json) else { return }
 
-        request.httpMethod = "PATCH"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildRoles, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(role)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(DiscordRole(roleObject: role))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildRoles(guild: guildId),
+                                   token: token,
+                                   method: .patch(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func removeGuildBan(for userId: String, on guildId: String, callback: ((Bool) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildBanUser, replacing: [
-            "guild.id": guildId,
-            "user.id": userId
-        ])
-
-        request.httpMethod = "DELETE"
-
         DefaultDiscordLogger.Logger.log("Unbanning \(userId) on \(guildId)", type: "DiscordEndpointGuild")
 
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildBans, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .guildBanUser(guild: guildId, user: userId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation.
     public func removeGuildMemberRole(_ roleId: String, from userId: String, on guildId: String,
                                       callback: ((Bool) -> ())?) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildMemberRole, replacing: [
-            "guild.id": guildId,
-            "user.id": userId,
-            "role.id": roleId
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildMemberRole, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
-            callback?(response?.statusCode == 204)
-        })
+        rateLimiter.executeRequest(endpoint: .guildMemberRole(guild: guildId, user: userId, role: roleId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
     /// Default implementation
     public func removeGuildRole(_ roleId: String, on guildId: String, callback: ((DiscordRole?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .guildRole, replacing: [
-            "guild.id": guildId,
-            "role.id": roleId
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildRoles, parameters: ["guild.id": guildId])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(role)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(DiscordRole(roleObject: role))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .guildRole(guild: guildId, role: roleId),
+                                   token: token,
+                                   method: .delete,
+                                   callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
@@ -23,7 +23,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                    callback: ((Bool) -> ())?) {
         rateLimiter.executeRequest(endpoint: .guildMemberRole(guild: guildId, user: userId, role: roleId),
                                    token: token,
-                                   method: .put(content: nil),
+                                   requestInfo: .put(content: nil),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -60,7 +60,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
                                    token: token,
-                                   method: .post(content: (contentData, type: .json)),
+                                   requestInfo: .post(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -100,7 +100,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildRoles(guild: guildId),
                                    token: token,
-                                   method: .post(content: (contentData, type: .json)),
+                                   requestInfo: .post(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -117,7 +117,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guilds(id: guildId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: requestCallback)
     }
 
@@ -133,7 +133,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildBans(guild: guildId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -148,7 +148,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -163,7 +163,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildMember(guild: guildId, user: id),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -192,7 +192,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildMembers(guild: guildId),
                                    token: token,
-                                   method: .get(params: getParams),
+                                   requestInfo: .get(params: getParams),
                                    callback: requestCallback)
     }
 
@@ -207,7 +207,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildRoles(guild: guildId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -218,7 +218,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         rateLimiter.executeRequest(endpoint: .guildBanUser(guild: guildId, user: userId),
                                    token: token,
-                                   method: .put(content: (contentData, .json)),
+                                   requestInfo: .put(content: (contentData, .json)),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
         }
 
@@ -263,7 +263,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guilds(id: guildId),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -283,7 +283,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -309,7 +309,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         rateLimiter.executeRequest(endpoint: .guildMember(guild: guildId, user: id),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -326,7 +326,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildRoles(guild: guildId),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -336,7 +336,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
 
         rateLimiter.executeRequest(endpoint: .guildBanUser(guild: guildId, user: userId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -345,7 +345,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                       callback: ((Bool) -> ())?) {
         rateLimiter.executeRequest(endpoint: .guildMemberRole(guild: guildId, user: userId, role: roleId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -360,7 +360,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildRole(guild: guildId, role: roleId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Invites.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Invites.swift
@@ -29,7 +29,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .invites(code: invite),
                                    token: token,
-                                   method: .post(content: nil),
+                                   requestInfo: .post(content: nil),
                                    callback: requestCallback)
     }
 
@@ -44,7 +44,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .invites(code: invite),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: requestCallback)
     }
 
@@ -59,7 +59,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .invites(code: invite),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Invites.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Invites.swift
@@ -20,59 +20,46 @@ import Foundation
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
     public func acceptInvite(_ invite: String, callback: ((DiscordInvite?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .invites, replacing: [
-            "invite.code": invite,
-        ])
-
-        request.httpMethod = "POST"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .invites, parameters: ["invite.code": invite])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(invite)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(DiscordInvite(inviteObject: invite))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .invites(code: invite),
+                                   token: token,
+                                   method: .post(content: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func deleteInvite(_ invite: String, callback: ((DiscordInvite?) -> ())? = nil) {
-        var request = DiscordEndpoint.createRequest(with: token, for: .invites, replacing: [
-            "invite.code": invite,
-        ])
-
-        request.httpMethod = "DELETE"
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .invites, parameters: ["invite.code": invite])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(invite)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
-
                 return
             }
-
             callback?(DiscordInvite(inviteObject: invite))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .invites(code: invite),
+                                   token: token,
+                                   method: .delete,
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getInvite(_ invite: String, callback: @escaping (DiscordInvite?) -> ()) {
-        let request = DiscordEndpoint.createRequest(with: token, for: .invites, replacing: ["invite.code": invite])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .invites, parameters: ["invite.code": invite])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(invite)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
-
                 return
             }
-
             callback(DiscordInvite(inviteObject: invite))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .invites(code: invite),
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
@@ -56,7 +56,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            DefaultDiscordLogger.Logger.debug("Got DMChannels: %@", type: "DiscordEndpointUser", args: channels)
+            DefaultDiscordLogger.Logger.debug("Got DMChannels: \(channels)", type: "DiscordEndpointUser")
 
             callback(DiscordDMChannel.DMsfromArray(channels as! [[String: Any]]))
         })

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
@@ -20,56 +20,41 @@ import Foundation
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
     public func createDM(with: String, callback: @escaping (DiscordDMChannel?) -> ()) {
-        guard let user = self.user, let contentData = JSON.encodeJSONData(["recipient_id": with]) else { return }
+        guard let contentData = JSON.encodeJSONData(["recipient_id": with]) else { return }
 
-        var request = DiscordEndpoint.createRequest(with: token, for: .userChannels, replacing: ["me": user.id])
-
-        request.httpMethod = "POST"
-        request.httpBody = contentData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(contentData.count), forHTTPHeaderField: "Content-Length")
-
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .userChannels, parameters: ["me": user.id])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(channel)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
-
                 return
             }
-
             callback(DiscordDMChannel(dmObject: channel))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .userChannels,
+                                   token: token,
+                                   method: .post(content: (contentData, type: .json)),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getDMs(callback: @escaping ([String: DiscordDMChannel]) -> ()) {
-        guard let user = self.user else { return callback([:]) }
-
-        let request = DiscordEndpoint.createRequest(with: token, for: .userChannels, replacing: ["me": user.id])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .userChannels, parameters: ["me": user.id])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(channels)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([:])
 
                 return
             }
-
             DefaultDiscordLogger.Logger.debug("Got DMChannels: \(channels)", type: "DiscordEndpointUser")
-
             callback(DiscordDMChannel.DMsfromArray(channels as! [[String: Any]]))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .userChannels,
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 
     /// Default implementation
     public func getGuilds(callback: @escaping ([String: DiscordUserGuild]) -> ()) {
-        guard let user = self.user else { return callback([:]) }
-
-        let request = DiscordEndpoint.createRequest(with: token, for: .userGuilds, replacing: ["me": user.id])
-        let rateLimiterKey = DiscordRateLimitKey(endpoint: .userGuilds, parameters: ["me": user.id])
-
-        rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
+        let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .array(guilds)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([:])
 
@@ -77,6 +62,10 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
 
             callback(DiscordUserGuild.userGuildsFromArray(guilds as! [[String: Any]]))
-        })
+        }
+        rateLimiter.executeRequest(endpoint: .userGuilds,
+                                   token: token,
+                                   method: .get(params: nil),
+                                   callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
@@ -31,7 +31,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .userChannels,
                                    token: token,
-                                   method: .post(content: (contentData, type: .json)),
+                                   requestInfo: .post(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -48,7 +48,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .userChannels,
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -65,7 +65,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .userGuilds,
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Webhooks.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Webhooks.swift
@@ -45,7 +45,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .channelWebhooks(channel: channelId),
                                    token: token,
-                                   method: .post(content: (contentData, type: .json)),
+                                   requestInfo: .post(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 
@@ -53,7 +53,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func deleteWebhook(_ webhookId: String, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .webhook(id: webhookId),
                                    token: token,
-                                   method: .delete,
+                                   requestInfo: .delete,
                                    callback: { _, response, _ in callback?(response?.statusCode == 204) })
     }
 
@@ -68,7 +68,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .webhook(id: webhookId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -83,7 +83,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .channelWebhooks(channel: channelId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -100,7 +100,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .guildWebhooks(guild: guildId),
                                    token: token,
-                                   method: .get(params: nil),
+                                   requestInfo: .get(params: nil),
                                    callback: requestCallback)
     }
 
@@ -131,7 +131,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
         rateLimiter.executeRequest(endpoint: .webhook(id: webhookId),
                                    token: token,
-                                   method: .patch(content: (contentData, type: .json)),
+                                   requestInfo: .patch(content: (contentData, type: .json)),
                                    callback: requestCallback)
     }
 }

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Webhooks.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Webhooks.swift
@@ -32,7 +32,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        DefaultDiscordLogger.Logger.debug("Creating webhook on: %@", type: "DiscordEndpointChannels", args: channelId)
+        DefaultDiscordLogger.Logger.debug("Creating webhook on: \(channelId)", type: "DiscordEndpointChannels")
 
         guard let contentData = JSON.encodeJSONData(createJSON) else { return }
 
@@ -75,7 +75,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         let request = DiscordEndpoint.createRequest(with: token, for: .webhook, replacing: ["webhook.id": webhookId])
         let rateLimiterKey = DiscordRateLimitKey(endpoint: .webhook, parameters: ["webhook.id": webhookId])
 
-        DefaultDiscordLogger.Logger.debug("Getting webhook: %@", type: "DiscordEndpointWebhooks", args: webhookId)
+        DefaultDiscordLogger.Logger.debug("Getting webhook: \(webhookId)", type: "DiscordEndpointWebhooks")
 
         rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
             guard case let .object(webhook)? = JSON.jsonFromResponse(data: data, response: response) else {
@@ -94,8 +94,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                                     replacing: ["channel.id": channelId])
         let rateLimiterKey = DiscordRateLimitKey(endpoint: .channelWebhooks, parameters: ["channel.id": channelId])
 
-        DefaultDiscordLogger.Logger.debug("Getting webhooks for channel: %@", type: "DiscordEndpointWebhooks",
-                                          args: channelId)
+        DefaultDiscordLogger.Logger.debug("Getting webhooks for channel: \(channelId)", type: "DiscordEndpointWebhooks")
 
         rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
             guard case let .array(webhooks)? = JSON.jsonFromResponse(data: data, response: response) else {
@@ -113,8 +112,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         let request = DiscordEndpoint.createRequest(with: token, for: .guildWebhooks, replacing: ["guild.id": guildId])
         let rateLimiterKey = DiscordRateLimitKey(endpoint: .guildWebhooks, parameters: ["guild.id": guildId])
 
-        DefaultDiscordLogger.Logger.debug("Getting webhooks for guild: %@", type: "DiscordEndpointWebhooks",
-                                          args: guildId)
+        DefaultDiscordLogger.Logger.debug("Getting webhooks for guild: \(guildId)", type: "DiscordEndpointWebhooks")
 
         rateLimiter.executeRequest(request, for: rateLimiterKey, callback: {data, response, error in
             guard case let .array(webhooks)? = JSON.jsonFromResponse(data: data, response: response) else {
@@ -141,7 +139,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        DefaultDiscordLogger.Logger.debug("Modifying webhook: %@", type: "DiscordEndpointChannels", args: webhookId)
+        DefaultDiscordLogger.Logger.debug("Modifying webhook: \(webhookId)", type: "DiscordEndpointChannels")
 
         guard let contentData = JSON.encodeJSONData(createJSON) else { return }
 

--- a/Sources/SwiftDiscord/DiscordEngine.swift
+++ b/Sources/SwiftDiscord/DiscordEngine.swift
@@ -147,7 +147,7 @@ open class DiscordEngine : DiscordEngineSpec {
         Disconnects the engine. An `engine.disconnect` is fired on disconnection.
     */
     public func disconnect() {
-        DefaultDiscordLogger.Logger.log("Disconnecting, %@", type: "DiscordWebSocketable", args: description)
+        DefaultDiscordLogger.Logger.log("Disconnecting, \(description)", type: "DiscordWebSocketable")
 
         closed = true
 
@@ -165,7 +165,7 @@ open class DiscordEngine : DiscordEngineSpec {
         connected = false
         heartbeatQueue.sync { self.pongsMissed = 0 }
 
-        DefaultDiscordLogger.Logger.log("Disconnected, shard: %@", type: logType, args: shardNum)
+        DefaultDiscordLogger.Logger.log("Disconnected, shard: \(shardNum)", type: logType)
 
         if closeReason == .sessionTimeout {
             sessionId = nil
@@ -187,7 +187,7 @@ open class DiscordEngine : DiscordEngineSpec {
     */
     open func handleDispatch(_ payload: DiscordGatewayPayload) {
         guard let type = payload.name, let event = DiscordDispatchEvent(rawValue: type) else {
-            DefaultDiscordLogger.Logger.error("Could not create dispatch event %@", type: logType, args: payload)
+            DefaultDiscordLogger.Logger.error("Could not create dispatch event \(payload)", type: logType)
 
             return
         }
@@ -276,7 +276,7 @@ open class DiscordEngine : DiscordEngineSpec {
         Handles the resumed event. You shouldn't call this directly.
     */
     open func handleResumed(_ payload: DiscordGatewayPayload) {
-        DefaultDiscordLogger.Logger.log("Resumed gateway session on shard: %@", type: logType, args: shardNum)
+        DefaultDiscordLogger.Logger.log("Resumed gateway session on shard: \(shardNum)", type: logType)
 
         resuming = false
 
@@ -311,7 +311,7 @@ open class DiscordEngine : DiscordEngineSpec {
             return
         }
 
-        DefaultDiscordLogger.Logger.log("Trying to resume gateway session on shard: %@", type: logType, args: shardNum)
+        DefaultDiscordLogger.Logger.log("Trying to resume gateway session on shard: \(shardNum)", type: logType)
 
         resuming = true
 
@@ -322,8 +322,8 @@ open class DiscordEngine : DiscordEngineSpec {
         handleQueue.asyncAfter(deadline: DispatchTime.now() + Double(wait)) {[weak self] in
             guard let this = self, this.resuming else { return }
 
-            DefaultDiscordLogger.Logger.debug("Calling engine connect for gateway resume with wait: %@",
-                type: this.logType, args: wait)
+            DefaultDiscordLogger.Logger.debug("Calling engine connect for gateway resume with wait: \(wait)",
+                type: this.logType)
 
             this.connect()
 
@@ -338,14 +338,13 @@ open class DiscordEngine : DiscordEngineSpec {
     */
     open func sendHeartbeat() {
         guard connected else {
-            DefaultDiscordLogger.Logger.debug("Tried heartbeating on disconnected shard, shard: %@", type: logType,
-                                              args: shardNum)
+            DefaultDiscordLogger.Logger.debug("Tried heartbeating on disconnected shard, shard: \(shardNum)", type: logType)
 
             return
         }
 
         guard pongsMissed < 2 else {
-            DefaultDiscordLogger.Logger.log("Too many pongs missed; closing, shard: %@", type: logType, args: shardNum)
+            DefaultDiscordLogger.Logger.log("Too many pongs missed; closing, shard: \(shardNum)", type: logType)
 
             pongsMissed = 0
             closeWebSockets()
@@ -353,7 +352,7 @@ open class DiscordEngine : DiscordEngineSpec {
             return
         }
 
-        DefaultDiscordLogger.Logger.debug("Sending heartbeat, shard: %@", type: logType, args: shardNum)
+        DefaultDiscordLogger.Logger.debug("Sending heartbeat, shard: \(shardNum)", type: logType)
 
         pongsMissed += 1
         sendPayload(DiscordGatewayPayload(code: .gateway(.heartbeat), payload: .integer(lastSequenceNumber)))
@@ -380,11 +379,11 @@ open class DiscordEngine : DiscordEngineSpec {
         }
 
         if sessionId != nil {
-            DefaultDiscordLogger.Logger.log("Sending resume, shard: %@", type: logType, args: shardNum)
+            DefaultDiscordLogger.Logger.log("Sending resume, shard: \(shardNum)", type: logType)
 
             sendPayload(DiscordGatewayPayload(code: .gateway(.resume), payload: .object(resumeObject)))
         } else {
-            DefaultDiscordLogger.Logger.log("Sending handshake, shard: %@", type: logType, args: shardNum)
+            DefaultDiscordLogger.Logger.log("Sending handshake, shard: \(shardNum)", type: logType)
 
             sendPayload(DiscordGatewayPayload(code: .gateway(.identify), payload: .object(handshakeObject)))
         }

--- a/Sources/SwiftDiscord/DiscordEngineSpec.swift
+++ b/Sources/SwiftDiscord/DiscordEngineSpec.swift
@@ -90,8 +90,7 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         websocket?.onConnect = {[weak self] in
             guard let this = self else { return }
 
-            DefaultDiscordLogger.Logger.log("WebSocket Connected, %@", type: "DiscordWebSocketable",
-                                            args: this.description)
+            DefaultDiscordLogger.Logger.log("WebSocket Connected, \(this.description)", type: "DiscordWebSocketable")
 
             this.connectUUID = UUID()
 
@@ -101,8 +100,7 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         websocket?.onDisconnect = {[weak self] err in
             guard let this = self else { return }
 
-            DefaultDiscordLogger.Logger.log("WebSocket disconnected %@, %@", type: "DiscordWebSocketable",
-                                            args: String(describing: err), this.description)
+            DefaultDiscordLogger.Logger.log("WebSocket disconnected \(String(describing: err)), \(this.description)", type: "DiscordWebSocketable")
 
             this.handleClose(reason: err)
         }
@@ -110,8 +108,7 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         websocket?.onText = {[weak self] string in
             guard let this = self else { return }
 
-            DefaultDiscordLogger.Logger.debug("%@ Got text: %@", type: "DiscordWebSocketable",
-                                              args: this.description, string)
+            DefaultDiscordLogger.Logger.debug("\(this.description) Got text: \(string)", type: "DiscordWebSocketable")
 
             this.parseGatewayMessage(string)
         }
@@ -119,8 +116,7 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         websocket?.onText = {[weak self] ws, text in
             guard let this = self else { return }
 
-            DefaultDiscordLogger.Logger.debug("%@, Got text: %@", type: "DiscordWebSocketable",
-                                              args: this.description, text)
+            DefaultDiscordLogger.Logger.debug("\(this.description), Got text: \(text)", type: "DiscordWebSocketable")
 
             this.parseGatewayMessage(text)
         }
@@ -128,8 +124,7 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         websocket?.onClose = {[weak self] _, _, _, _ in
             guard let this = self else { return }
 
-            DefaultDiscordLogger.Logger.log("WebSocket closed, %@", type: "DiscordWebSocketable",
-                                            args: this.description)
+            DefaultDiscordLogger.Logger.log("WebSocket closed, \(this.description)", type: "DiscordWebSocketable")
 
             this.handleClose()
         }
@@ -140,10 +135,8 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         Starts the connection to the Discord gateway.
     */
     public func connect() {
-        DefaultDiscordLogger.Logger.log("Connecting to %@, %@", type: "DiscordWebSocketable",
-                                        args: connectURL, description)
-        DefaultDiscordLogger.Logger.log("Attaching WebSocket, shard: %@", type: "DiscordWebSocketable",
-                                        args: description)
+        DefaultDiscordLogger.Logger.log("Connecting to \(connectURL), \(description)", type: "DiscordWebSocketable")
+        DefaultDiscordLogger.Logger.log("Attaching WebSocket, shard: \(description)", type: "DiscordWebSocketable")
 
         #if !os(Linux)
         websocket = WebSocket(url: URL(string: connectURL)!)
@@ -154,8 +147,7 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable {
         #else
         try? WebSocket.background(to: connectURL) {[weak self] ws in
             guard let this = self else { return }
-            DefaultDiscordLogger.Logger.log("Websocket connected, shard: ", type: "DiscordWebSocketable",
-                                            args: this.description)
+            DefaultDiscordLogger.Logger.log("Websocket connected, shard: \(this.description)", type: "DiscordWebSocketable")
 
             this.websocket = ws
             this.connectUUID = UUID()

--- a/Sources/SwiftDiscord/DiscordGateway.swift
+++ b/Sources/SwiftDiscord/DiscordGateway.swift
@@ -97,7 +97,7 @@ public extension DiscordGatewayable where Self: DiscordWebSocketable {
             return
         }
 
-        DefaultDiscordLogger.Logger.debug("Sending ws: %@", type: description, args: payloadString)
+        DefaultDiscordLogger.Logger.debug("Sending ws: \(payloadString)", type: description)
 
         #if !os(Linux)
         websocket?.write(string: payloadString)

--- a/Sources/SwiftDiscord/DiscordGuild.swift
+++ b/Sources/SwiftDiscord/DiscordGuild.swift
@@ -158,7 +158,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
     public func createChannel(with options: [DiscordEndpoint.Options.GuildCreateChannel]) {
         guard let client = self.client else { return }
 
-        DefaultDiscordLogger.Logger.log("Creating guild channel on %@", type: "DiscordGuild", args: id)
+        DefaultDiscordLogger.Logger.log("Creating guild channel on \(id)", type: "DiscordGuild")
 
         client.createGuildChannel(on: id, options: options)
     }
@@ -204,7 +204,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
         var guildMember: DiscordGuildMember?
 
         client.getGuildMember(by: userId, on: id) {member in
-            DefaultDiscordLogger.Logger.debug("Got member: %@", type: "DiscordGuild", args: userId)
+            DefaultDiscordLogger.Logger.debug("Got member: \(userId)", type: "DiscordGuild")
 
             guildMember = member
 
@@ -277,14 +277,12 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
         let userId = presence.user.id
 
         if pruneUsers && presence.status == .offline {
-            DefaultDiscordLogger.Logger.debug("Pruning guild member %@ on %@", type: DiscordGuild.logType,
-                                              args: userId, id)
+            DefaultDiscordLogger.Logger.debug("Pruning guild member \(userId) on \(id)", type: DiscordGuild.logType)
 
             members[userId] = nil
             presences[userId] = nil
         } else if fillUsers && !members.contains(userId) {
-            DefaultDiscordLogger.Logger.debug("Should get member %@; pull from the API", type: DiscordGuild.logType,
-                                              args: userId)
+            DefaultDiscordLogger.Logger.debug("Should get member \(userId); pull from the API", type: DiscordGuild.logType)
 
             members[lazy: userId] = .lazy({[weak self] in
                 guard let this = self else {
@@ -349,7 +347,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
     public func unban(_ user: DiscordUser) {
         guard let client = self.client else { return }
 
-        DefaultDiscordLogger.Logger.log("Unbanning user %@ on %@", type: "DiscordGuild", args: user, id)
+        DefaultDiscordLogger.Logger.log("Unbanning user \(user) on \(id)", type: "DiscordGuild")
 
         client.removeGuildBan(for: user.id, on: id)
     }

--- a/Sources/SwiftDiscord/DiscordGuildChannel.swift
+++ b/Sources/SwiftDiscord/DiscordGuildChannel.swift
@@ -132,8 +132,7 @@ extension DiscordGuildChannel {
 func guildChannelFromObject(_ channelObject: [String: Any], client: DiscordClient? = nil) -> DiscordGuildChannel {
     if channelObject["type"] as? Int == DiscordChannelType.voice.rawValue {
         return DiscordGuildVoiceChannel(guildChannelObject: channelObject, client: client)
-    }
-    else {
+    } else {
         return DiscordGuildTextChannel(guildChannelObject: channelObject, client: client)
     }
 }

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -118,7 +118,7 @@ extension JSONAble {
                 do {
                     json[name.snakecase] = try sendable.jsonValue()
                 } catch {
-                    DefaultDiscordLogger.Logger.error("Couldn't json property %@", type: "JSONAble", args: name)
+                    DefaultDiscordLogger.Logger.error("Couldn't json property \(name)", type: "JSONAble")
                 }
             }
         }

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -22,12 +22,11 @@ enum JSON {
     case object([String: Any])
 
     static func encodeJSONData(_ object: Any) -> Data? {
-        return encodeJSON(object)?.data(using: .utf8)
+        return try? JSONSerialization.data(withJSONObject: object)
     }
 
     static func encodeJSON(_ object: Any) -> String? {
-        guard let data = try? JSONSerialization.data(withJSONObject: object) else { return nil }
-
+        guard let data = encodeJSONData(object) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 

--- a/Sources/SwiftDiscord/DiscordLogger.swift
+++ b/Sources/SwiftDiscord/DiscordLogger.swift
@@ -39,55 +39,47 @@ public protocol DiscordLogger {
     // MARK: Methods
 
     /// Normal log messages.
-    func log(_ message: String, type: String, args: Any...)
+    func log( _ message: @autoclosure () -> String, type: String)
 
     /// More info on log messages.
-    func verbose(_ message: String, type: String, args: Any...)
+    func verbose(_ message: @autoclosure () -> String, type: String)
 
     /// Debug messages.
-    func debug(_ message: String, type: String, args: Any...)
+    func debug(_ message: @autoclosure () -> String, type: String)
 
     /// Error Messages.
-    func error(_ message: String, type: String, args: Any...)
+    func error(_ message: @autoclosure () -> String, type: String)
 }
 
 public extension DiscordLogger {
     /// Normal log messages.
-    func log(_ message: String, type: String, args: Any...) {
+    func log(_ message: @autoclosure () -> String, type: String) {
         guard level == .info || level == .verbose || level == .debug else { return }
 
-        abstractLog("LOG", message: message, type: type, args: args)
+        abstractLog("LOG", message: message(), type: type)
     }
 
     /// More info on log messages.
-    func verbose(_ message: String, type: String, args: Any...) {
+    func verbose(_ message: @autoclosure () -> String, type: String) {
         guard level == .verbose || level == .debug else { return }
 
-        abstractLog("VERBOSE", message: message, type: type, args: args)
+        abstractLog("VERBOSE", message: message(), type: type)
     }
 
     /// Debug messages.
-    func debug(_ message: String, type: String, args: Any...) {
+    func debug(_ message: @autoclosure () -> String, type: String) {
         guard level == .debug else { return }
 
-        abstractLog("DEBUG", message: message, type: type, args: args)
+        abstractLog("DEBUG", message: message(), type: type)
     }
 
     /// Error Messages.
-    func error(_ message: String, type: String, args: Any...) {
-        abstractLog("ERROR", message: message, type: type, args: args)
+    func error(_ message: @autoclosure () -> String, type: String) {
+        abstractLog("ERROR", message: message(), type: type)
     }
 
-    private func abstractLog(_ logType: String, message: String, type: String, args: [Any]) {
-        var message = "\(logType): \(type): \(message)"
-
-        for arg in args {
-            guard let range = message.range(of: "%@") else { break }
-
-            message.replaceSubrange(range, with: String(describing: arg))
-        }
-
-        NSLog(message)
+    private func abstractLog(_ logType: String, message: String, type: String) {
+        NSLog("\(logType): \(type): \(message)")
     }
 }
 

--- a/Sources/SwiftDiscord/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/DiscordRateLimiter.swift
@@ -55,7 +55,7 @@ public final class DiscordRateLimiter {
             let rateLimit = endpointLimits[endpointKey]!
 
             if rateLimit.atLimit {
-                DefaultDiscordLogger.Logger.debug("Hit rate limit: %@", type: "DiscordRateLimiter", args: rateLimit)
+                DefaultDiscordLogger.Logger.debug("Hit rate limit: \(rateLimit)", type: "DiscordRateLimiter")
 
                 // We've hit a rate limit, enqueue this request for later
                 rateLimit.queue.append(RateLimitedRequest(request: request, callback: callback))
@@ -65,8 +65,7 @@ public final class DiscordRateLimiter {
 
             rateLimit.remaining -= 1
 
-            DefaultDiscordLogger.Logger.debug("Doing request: %@, remaining: %@", type: "DiscordRateLimiter",
-                                              args: request, rateLimit.remaining)
+            DefaultDiscordLogger.Logger.debug("Doing request: \(request), remaining: \(rateLimit.remaining)", type: "DiscordRateLimiter")
 
             session.dataTask(with: request,
                              completionHandler: createResponseHandler(for: request, endpointKey: endpointKey,
@@ -113,10 +112,9 @@ public final class DiscordRateLimiter {
                                            reset: Int(reset as! String)!)
                 }
 
-                DefaultDiscordLogger.Logger.debug("New limit: %@", type: "DiscordRateLimiter", args: rateLimit.limit)
-                DefaultDiscordLogger.Logger.debug("New remaining: %@", type: "DiscordRateLimiter",
-                                                  args: rateLimit.remaining)
-                DefaultDiscordLogger.Logger.debug("New reset: %@", type: "DiscordRateLimiter", args: rateLimit.reset)
+                DefaultDiscordLogger.Logger.debug("New limit: \(rateLimit.limit)", type: "DiscordRateLimiter")
+                DefaultDiscordLogger.Logger.debug("New remaining: \(rateLimit.remaining)", type: "DiscordRateLimiter")
+                DefaultDiscordLogger.Logger.debug("New reset: \(rateLimit.reset)", type: "DiscordRateLimiter")
 
                 callback(data, response, error)
             }
@@ -200,7 +198,7 @@ private final class DiscordRateLimit {
         scheduledReset = true
 
         queue.asyncAfter(deadline: deadlineForReset) {
-            DefaultDiscordLogger.Logger.debug("Reset triggered: %@", type: "RateLimit", args: self.endpointKey)
+            DefaultDiscordLogger.Logger.debug("Reset triggered: \(self.endpointKey)", type: "RateLimit")
             self.remaining = self.limit
             self.scheduledReset = false
 
@@ -216,8 +214,7 @@ private final class DiscordRateLimit {
                 removed += 1
             } while removed < self.remaining && self.queue.count != 0
 
-            DefaultDiscordLogger.Logger.debug("Sent %@ requests for limit: %@", type: "RateLimit",
-                args: removed, self.endpointKey)
+            DefaultDiscordLogger.Logger.debug("Sent \(removed) requests for limit: \(self.endpointKey)", type: "RateLimit")
         }
     }
 

--- a/Sources/SwiftDiscord/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/DiscordRateLimiter.swift
@@ -157,11 +157,11 @@ public struct DiscordRateLimitKey: Hashable {
 
     /// Creates a new endpoint key.
     public init(endpoint: DiscordEndpoint) {
-		if case let .channelMessageDelete(channel, _) = endpoint {
-			self.key = DiscordEndpoint.messages(channel: channel).description + "d"
-		} else {
-			self.key = endpoint.description
-		}
+        if case let .channelMessageDelete(channel, _) = endpoint {
+            self.key = DiscordEndpoint.messages(channel: channel).description + "d"
+        } else {
+            self.key = endpoint.description
+        }
     }
 
     /// Whether two keys are equal.

--- a/Sources/SwiftDiscord/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/DiscordRateLimiter.swift
@@ -18,8 +18,8 @@
 import Foundation
 import Dispatch
 
-private typealias RequestCallback = (Data?, HTTPURLResponse?, Error?) -> ()
-private typealias RateLimitedRequest = (request: URLRequest, callback: RequestCallback)
+public typealias DiscordRequestCallback = (Data?, HTTPURLResponse?, Error?) -> ()
+private typealias RateLimitedRequest = (request: URLRequest, callback: DiscordRequestCallback)
 
 /// The DiscordRateLimiter is in charge of making sure we don't flood Discord with requests.
 /// It keeps a dictionary of DiscordRateLimitKeys and DiscordRateLimits.
@@ -44,7 +44,7 @@ public final class DiscordRateLimiter {
         - parameter callback: The callback for this request.
     */
     public func executeRequest(_ request: URLRequest, for endpointKey: DiscordRateLimitKey,
-                               callback: @escaping (Data?, HTTPURLResponse?, Error?) -> ()) {
+                               callback: @escaping DiscordRequestCallback) {
         func _executeRequest() {
             if endpointLimits[endpointKey] == nil {
                 // First time handling this endpoint, err on the side caution and limit to one
@@ -75,8 +75,21 @@ public final class DiscordRateLimiter {
         limitQueue.async(execute: _executeRequest)
     }
 
+    public func executeRequest(endpoint: DiscordEndpoint,
+                                  token: DiscordToken,
+                                 method: HTTPMethod,
+                               callback: @escaping DiscordRequestCallback) {
+        let rateLimitKey = DiscordRateLimitKey(for: endpoint)
+        guard let request = endpoint.createRequest(with: token, method: method) else {
+            // Error is logged by createRequest
+            return
+        }
+
+        executeRequest(request, for: rateLimitKey, callback: callback)
+    }
+
     private func createResponseHandler(for request: URLRequest, endpointKey: DiscordRateLimitKey,
-                                       callback: @escaping RequestCallback) -> (Data?, URLResponse?, Error?) -> () {
+                                       callback: @escaping DiscordRequestCallback) -> (Data?, URLResponse?, Error?) -> () {
         func _createResponseHandler(data: Data?, response: URLResponse?, error: Error?) {
             func _responseHandler() {
                 let rateLimit = endpointLimits[endpointKey]!
@@ -126,36 +139,138 @@ public final class DiscordRateLimiter {
     }
 }
 
+/// URL Parts for the purpose of rate limiting
+public struct DiscordRateLimitURLParts: OptionSet {
+    public let rawValue: Int
+
+    static let guilds = DiscordRateLimitURLParts(rawValue: 1 << 0)
+    static let channels = DiscordRateLimitURLParts(rawValue: 1 << 1)
+    static let messages = DiscordRateLimitURLParts(rawValue: 1 << 2)
+    static let messagesDelete = DiscordRateLimitURLParts(rawValue: 1 << 3)
+    static let bulkDelete = DiscordRateLimitURLParts(rawValue: 1 << 4)
+    static let typing = DiscordRateLimitURLParts(rawValue: 1 << 5)
+    static let permissions = DiscordRateLimitURLParts(rawValue: 1 << 6)
+    static let invites = DiscordRateLimitURLParts(rawValue: 1 << 7)
+    static let pins = DiscordRateLimitURLParts(rawValue: 1 << 8)
+    static let webhooks = DiscordRateLimitURLParts(rawValue: 1 << 9)
+    static let members = DiscordRateLimitURLParts(rawValue: 1 << 10)
+    static let roles = DiscordRateLimitURLParts(rawValue: 1 << 11)
+    static let bans = DiscordRateLimitURLParts(rawValue: 1 << 12)
+    static let users = DiscordRateLimitURLParts(rawValue: 1 << 13)
+    static let slack = DiscordRateLimitURLParts(rawValue: 1 << 14)
+    static let github = DiscordRateLimitURLParts(rawValue: 1 << 15)
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}
+
 /// An endpoint is made up of a REST api endpoint and any major parameters in that endpoint.
 /// Ex. /channels/232184444340011009/messages and /channels/186926276592795659/messages
 /// Are considered different endpoints
 public struct DiscordRateLimitKey: Hashable {
     // MARK: Properties
 
-    /// The raw key for this endpoint.
-    public let key: String
+    /// The guild or channel ID in this endpoint (or "" if neither)
+    public let id: String
+    /// The url parts in this endpoint
+    public let urlParts: DiscordRateLimitURLParts
 
     /// The hash of the key.
     public var hashValue: Int {
-        return key.hashValue
+        return (urlParts.rawValue << 5) &+ urlParts.rawValue &+ id.hashValue
     }
 
     // MARK: Initializers
 
     /// Creates a new endpoint key.
-    public init(endpoint: DiscordEndpoint, parameters: [String: String]) {
-        var key = endpoint.rawValue
+    public init(for endpoint: DiscordEndpoint) {
+        switch endpoint {
+        case .baseURL:
+            DefaultDiscordLogger.Logger.error("Attempted to get rate limit key for base URL", type: "DiscordEndpoint")
+            id = ""; urlParts = []
 
-        for (param, value) in parameters {
-            key = key.replacingOccurrences(of: param, with: value)
+        // -- Channels --
+        case let .channel(id):
+            self.id = id; urlParts = [.channels]
+        // Messages
+        case let .messages(channel):
+            id = channel; urlParts = [.channels, .messages]
+        case let .bulkMessageDelete(channel):
+            id = channel; urlParts = [.channels, .bulkDelete]
+        case let .channelMessage(channel, _):
+            id = channel; urlParts = [.channels, .messages]
+        case let .channelMessageDelete(channel, _):
+            id = channel; urlParts = [.channels, .messagesDelete]
+        case let .typing(channel):
+            id = channel; urlParts = [.channels, .typing]
+        // Permissions
+        case let .permissions(channel):
+            id = channel; urlParts = [.channels, .permissions]
+        case let .channelPermission(channel, _):
+            id = channel; urlParts = [.channels, .permissions]
+        // Invites
+        case .invites:
+            id = ""; urlParts = [.invites]
+        case let .channelInvites(channel):
+            id = channel; urlParts = [.channels, .invites]
+        // Pinned Messages
+        case let .pins(channel):
+            id = channel; urlParts = [.channels, .pins]
+        case let .pinnedMessage(channel, _):
+            id = channel; urlParts = [.channels, .pins]
+        // Webhooks
+        case let .channelWebhooks(channel):
+            id = channel; urlParts = [.channels, .webhooks]
+
+        // -- Guilds --
+        case let .guilds(id):
+            self.id = id; urlParts = [.guilds]
+        // Guild Channels
+        case let .guildChannels(guild):
+            id = guild; urlParts = [.guilds, .channels]
+        // Guild Members
+        case let .guildMembers(guild):
+            id = guild; urlParts = [.guilds, .members]
+        case let .guildMember(guild, _):
+            id = guild; urlParts = [.guilds, .members]
+        case let .guildMemberRole(guild, _, _):
+            id = guild; urlParts = [.guilds, .members, .roles]
+        // Guild Bans
+        case let .guildBans(guild):
+            id = guild; urlParts = [.guilds, .bans]
+        case let .guildBanUser(guild, _):
+            id = guild; urlParts = [.guilds, .bans]
+        // Guild Roles
+        case let .guildRoles(guild):
+            id = guild; urlParts = [.guilds, .roles]
+        case let .guildRole(guild, _):
+            id = guild; urlParts = [.guilds, .roles]
+        // Webhooks
+        case let .guildWebhooks(guild):
+            id = guild; urlParts = [.guilds, .webhooks]
+
+        // -- User --
+        case .userChannels:
+            id = ""; urlParts = [.users, .channels]
+        case .userGuilds:
+            id = ""; urlParts = [.users, .guilds]
+
+        // -- Webhooks --
+        case .webhook:
+            id = ""; urlParts = [.webhooks]
+        case .webhookWithToken:
+            id = ""; urlParts = [.webhooks]
+        case .webhookSlack:
+            id = ""; urlParts = [.webhooks, .slack]
+        case .webhookGithub:
+            id = ""; urlParts = [.webhooks, .github]
         }
-
-        self.key = key
     }
 
     /// Whether two keys are equal.
     public static func ==(lhs: DiscordRateLimitKey, rhs: DiscordRateLimitKey) -> Bool {
-        return lhs.key == rhs.key
+        return lhs.id == rhs.id && lhs.urlParts == rhs.urlParts
     }
 }
 

--- a/Sources/SwiftDiscord/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/DiscordRateLimiter.swift
@@ -76,11 +76,11 @@ public final class DiscordRateLimiter {
     }
 
     public func executeRequest(endpoint: DiscordEndpoint,
-                                  token: DiscordToken,
-                                 method: HTTPMethod,
+                               token: DiscordToken,
+                               requestInfo: DiscordEndpoint.EndpointRequest,
                                callback: @escaping (Data?, HTTPURLResponse?, Error?) -> ()) {
         let rateLimitKey = DiscordRateLimitKey(endpoint: endpoint.endpointForRateLimiter)
-        guard let request = endpoint.createRequest(with: token, method: method) else {
+        guard let request = requestInfo.createRequest(with: token, endpoint: endpoint) else {
             // Error is logged by createRequest
             return
         }

--- a/Sources/SwiftDiscord/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/DiscordRateLimiter.swift
@@ -159,8 +159,7 @@ public struct DiscordRateLimitKey: Hashable {
     public init(endpoint: DiscordEndpoint) {
 		if case let .channelMessageDelete(channel, _) = endpoint {
 			self.key = DiscordEndpoint.messages(channel: channel).description + "d"
-		}
-		else {
+		} else {
 			self.key = endpoint.description
 		}
     }

--- a/Sources/SwiftDiscord/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/DiscordRateLimiter.swift
@@ -18,7 +18,7 @@
 import Foundation
 import Dispatch
 
-public typealias DiscordRequestCallback = (Data?, HTTPURLResponse?, Error?) -> ()
+internal typealias DiscordRequestCallback = (Data?, HTTPURLResponse?, Error?) -> ()
 private typealias RateLimitedRequest = (request: URLRequest, callback: DiscordRequestCallback)
 
 /// The DiscordRateLimiter is in charge of making sure we don't flood Discord with requests.
@@ -44,7 +44,7 @@ public final class DiscordRateLimiter {
         - parameter callback: The callback for this request.
     */
     public func executeRequest(_ request: URLRequest, for endpointKey: DiscordRateLimitKey,
-                               callback: @escaping DiscordRequestCallback) {
+                               callback: @escaping (Data?, HTTPURLResponse?, Error?) -> ()) {
         func _executeRequest() {
             if endpointLimits[endpointKey] == nil {
                 // First time handling this endpoint, err on the side caution and limit to one
@@ -78,7 +78,7 @@ public final class DiscordRateLimiter {
     public func executeRequest(endpoint: DiscordEndpoint,
                                   token: DiscordToken,
                                  method: HTTPMethod,
-                               callback: @escaping DiscordRequestCallback) {
+                               callback: @escaping (Data?, HTTPURLResponse?, Error?) -> ()) {
         let rateLimitKey = DiscordRateLimitKey(for: endpoint)
         guard let request = endpoint.createRequest(with: token, method: method) else {
             // Error is logged by createRequest

--- a/Sources/SwiftDiscord/DiscordSharding.swift
+++ b/Sources/SwiftDiscord/DiscordSharding.swift
@@ -237,8 +237,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
     open func manuallyShatter(withInfo info: DiscordShardInformation) {
         guard let delegate = self.delegate else { return }
 
-        DefaultDiscordLogger.Logger.verbose("Manually shattering shard #%@", type: "DiscordShardManager",
-                                            args: info.shardNum)
+        DefaultDiscordLogger.Logger.verbose("Manually shattering shard #\(info.shardNum)", type: "DiscordShardManager")
 
         cleanUp()
 
@@ -285,8 +284,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
         - parameter shardNum: The number of the shard that disconnected.
     */
     open func shardDidConnect(_ shard: DiscordShard) {
-        DefaultDiscordLogger.Logger.verbose("Shard #%@, connected", type: "DiscordShardManager",
-                                            args: shard.shardNum)
+        DefaultDiscordLogger.Logger.verbose("Shard #\(shard.shardNum), connected", type: "DiscordShardManager")
 
         protected { connectedShards += 1 }
 
@@ -301,8 +299,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
         - parameter shardNum: The number of the shard that disconnected.
     */
     open func shardDidDisconnect(_ shard: DiscordShard) {
-        DefaultDiscordLogger.Logger.verbose("Shard #%@, disconnected", type: "DiscordShardManager",
-                                            args: shard.shardNum)
+        DefaultDiscordLogger.Logger.verbose("Shard #\(shard.shardNum), disconnected", type: "DiscordShardManager")
 
         protected { closedShards += 1 }
 
@@ -319,8 +316,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
     open func shatter(into numberOfShards: Int) {
         guard let delegate = self.delegate else { return }
 
-        DefaultDiscordLogger.Logger.verbose("Shattering into %@ shards", type: "DiscordShardManager",
-                                            args: numberOfShards)
+        DefaultDiscordLogger.Logger.verbose("Shattering into \(numberOfShards) shards", type: "DiscordShardManager")
 
         cleanUp()
 

--- a/Sources/SwiftDiscord/DiscordVoiceDecoder.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceDecoder.swift
@@ -43,12 +43,10 @@ open class DiscordVoiceSessionDecoder {
         let decoder: DiscordOpusDecoder
 
         if let previous = decoders[ssrc] {
-            DefaultDiscordLogger.Logger.debug("Reusing decoder for ssrc: %@, seqNum: %@, timestamp: %@",
-                                              type: "DiscordVoiceSessionDecoder", args: ssrc, seqNum, timestamp)
+            DefaultDiscordLogger.Logger.debug("Reusing decoder for ssrc: \(ssrc), seqNum: \(seqNum), timestamp: \(timestamp)", type: "DiscordVoiceSessionDecoder")
             decoder = previous
         } else {
-            DefaultDiscordLogger.Logger.debug("New decoder for ssrc: %@, seqNum: %@, timestamp: %@",
-                                              type: "DiscordVoiceSessionDecoder", args: ssrc, seqNum, timestamp)
+            DefaultDiscordLogger.Logger.debug("New decoder for ssrc: \(ssrc), seqNum: \(seqNum), timestamp: \(timestamp)", type: "DiscordVoiceSessionDecoder")
             decoder = try DiscordOpusDecoder(sampleRate: 48_000, channels: 2)
             decoders[ssrc] = decoder
         }
@@ -70,8 +68,7 @@ open class DiscordVoiceSessionDecoder {
             timestamps[ssrc] = timestamp
 
             DefaultDiscordLogger.Logger.debug("Out of order packet", type: "DiscordVoiceSessionDecoder")
-            DefaultDiscordLogger.Logger.debug("Looks to have a sequence difference of %@",
-                                              type: "DiscordVoiceSessionDecoder", args: seqNum - previousSeqNum)
+            DefaultDiscordLogger.Logger.debug("Looks to have a sequence difference of \(seqNum - previousSeqNum)", type: "DiscordVoiceSessionDecoder")
 
             for _ in 0..<seqNum-previousSeqNum {
                 // TODO Don't hardcode the frameSize

--- a/Sources/SwiftDiscord/DiscordVoiceEncoder.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceEncoder.swift
@@ -179,7 +179,7 @@ open class DiscordVoiceEncoder {
 
         defer { free(buf) }
 
-        DefaultDiscordLogger.Logger.debug("Read %@ bytes", type: "DiscordVoiceEncoder", args: bytesRead)
+        DefaultDiscordLogger.Logger.debug("Read \(bytesRead) bytes", type: "DiscordVoiceEncoder")
 
         guard bytesRead > 0, !closed else {
             return (true, [])

--- a/Sources/SwiftDiscord/DiscordVoiceEngine.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceEngine.swift
@@ -197,7 +197,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
             return
         }
 
-        DefaultDiscordLogger.Logger.debug("Sleeping %@ %@", type: logType, args: waitTime, audioCount)
+        DefaultDiscordLogger.Logger.debug("Sleeping \(waitTime) \(audioCount)", type: logType)
 
         Thread.sleep(forTimeInterval: waitTime)
 
@@ -290,7 +290,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
     }
 
     private func extractIPAndPort(from bytes: [UInt8]) throws -> (String, Int) {
-        DefaultDiscordLogger.Logger.debug("Extracting ip and port from %@", type: logType, args: bytes)
+        DefaultDiscordLogger.Logger.debug("Extracting ip and port from \(bytes)", type: logType)
 
         let ipData = Data(bytes: bytes.dropLast(2))
         let portBytes = Array(bytes.suffix(from: bytes.endIndex.advanced(by: -2)))
@@ -372,9 +372,9 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
             udpQueueWrite.sync { self.handleVoiceSessionDescription(with: payload.payload) }
             sendSilence()
         case .speaking:
-            DefaultDiscordLogger.Logger.debug("Got speaking", type: logType, args: payload)
+            DefaultDiscordLogger.Logger.debug("Got speaking \(payload)", type: logType)
         default:
-            DefaultDiscordLogger.Logger.debug("Unhandled voice payload %@", type: logType, args: payload)
+            DefaultDiscordLogger.Logger.debug("Unhandled voice payload \(payload)", type: logType)
         }
     }
 
@@ -417,7 +417,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
     */
     public func parseGatewayMessage(_ string: String) {
         guard let decoded = DiscordGatewayPayload.payloadFromString(string, fromGateway: false) else {
-            DefaultDiscordLogger.Logger.log("Got unknown payload %@", type: logType, args: string)
+            DefaultDiscordLogger.Logger.log("Got unknown payload \(string)", type: logType)
 
             return
         }
@@ -439,7 +439,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
                 return
             }
 
-            DefaultDiscordLogger.Logger.debug("Read %@ bytes", type: this.logType, args: data.count)
+            DefaultDiscordLogger.Logger.debug("Read \(data.count) bytes", type: this.logType)
 
             this.sendVoiceData(data)
             this.readData()
@@ -453,7 +453,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
             do {
                 let (data, _) = try socket.recvfrom(maxBytes: 4096)
 
-                DefaultDiscordLogger.Logger.debug("Received data %@", type: "DiscordVoiceEngine", args: data)
+                DefaultDiscordLogger.Logger.debug("Received data \(data)", type: "DiscordVoiceEngine")
 
                 guard let this = self else { return }
 
@@ -575,7 +575,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
         func _sendVoiceData() {
             guard let udpSocket = self.udpSocket, secret != nil else { return }
 
-            DefaultDiscordLogger.Logger.debug("Should send voice data: %@ bytes", type: logType, args: data.count)
+            DefaultDiscordLogger.Logger.debug("Should send voice data: \(data.count) bytes", type: logType)
 
             do {
                 try udpSocket.sendto(data: createVoicePacket(data))


### PR DESCRIPTION
- Logging no longer uses `%@` + varargs.  Swift string interpolation should be used instead.  This prevents accidents where you include args but forget to include a `%@` in the string.  The calls are now lazy as well, so any string conversion you do will only be run if the result is going to be printed.
- `JSON.encodeJSONData` no longer converts the data to a string and back to data.  It seemed kind of unnecessary.
- Endpoint generation now uses enums with associated types and a separate method which generates urls instead of string replacement with a dictionary.  This means that you won't be able to forget a required piece or mistype its name.
- `DiscordEnpoint.createRequest` now takes the HTTP method and any data associated with it and fills the request object accordingly, so it should be much harder to accidentally leave one of those out (and much less to do in any method that makes requests).
- New `executeRequest` method for `DiscordRateLimiter` which takes an endpoint (with its associated data), a token, an HTTP method (and its associated data), and a callback and does everything else for you.
- New rate limit key creation which (I think) conforms to the spec listed on Discord's website.

Note: If you want to add a new endpoint, there are now three places where you have to add code.  They're all default-less switch statements, so the compiler should complain at you if you forget one.  One is the enum definition, one is in the enum's description method (where it actually creates the URL), and the third is in DiscordRateLimitKey's init (to indicate what parts to use as the rate limit key).