### PR TITLE
Snowflake as UInt64

### DIFF
--- a/Sources/SwiftDiscord/DiscordChannel.swift
+++ b/Sources/SwiftDiscord/DiscordChannel.swift
@@ -22,7 +22,7 @@ public protocol DiscordChannel : DiscordClientHolder {
     // MARK: Properties
 
     /// The id of the channel.
-    var id: String { get }
+    var id: ChannelID { get }
 
     /// Whether or not the channel is private
     var isPrivate: Bool { get }
@@ -32,7 +32,7 @@ public protocol DiscordChannel : DiscordClientHolder {
 public protocol DiscordTextChannel : DiscordChannel {
 
     /// The snowflake id of the last received message on this channel.
-    var lastMessageId: String { get }
+    var lastMessageId: MessageID { get }
 }
 
 /// Represents the type of a channel.
@@ -195,8 +195,8 @@ func channelFromObject(_ object: [String: Any], withClient client: DiscordClient
     }
 }
 
-func privateChannelsFromArray(_ channels: [[String: Any]], client: DiscordClient) -> [String: DiscordTextChannel] {
-    var channelDict = [String: DiscordTextChannel]()
+func privateChannelsFromArray(_ channels: [[String: Any]], client: DiscordClient) -> [ChannelID: DiscordTextChannel] {
+    var channelDict = [ChannelID: DiscordTextChannel]()
 
     for channel in channels {
         guard let channel = channelFromObject(channel, withClient: client) as? DiscordTextChannel else { continue }

--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -78,10 +78,10 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     public private(set) var connected = false
 
     /// The direct message channels this user is in.
-    public private(set) var directChannels = [String: DiscordTextChannel]()
+    public private(set) var directChannels = [ChannelID: DiscordTextChannel]()
 
     /// The guilds that this user is in.
-    public private(set) var guilds = [String: DiscordGuild]()
+    public private(set) var guilds = [GuildID: DiscordGuild]()
 
     /// The relationships this user has. Only valid for non-bot users.
     public private(set) var relationships = [[String: Any]]()
@@ -92,7 +92,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     /// A manager for the voice engines.
     public private(set) var voiceManager: DiscordVoiceManager!
 
-    var channelCache = [String: DiscordChannel]()
+    var channelCache = [ChannelID: DiscordChannel]()
 
     private var logType: String { return "DiscordClient" }
     private let voiceQueue = DispatchQueue(label: "voiceQueue")
@@ -179,7 +179,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         - parameter fromId: A channel snowflake
         - returns: An optional containing a `DiscordChannel` if one was found.
     */
-    public func findChannel(fromId channelId: String) -> DiscordChannel? {
+    public func findChannel(fromId channelId: ChannelID) -> DiscordChannel? {
         if let channel = channelCache[channelId] {
             DefaultDiscordLogger.Logger.debug("Got cached channel \(channel)", type: logType)
 
@@ -251,7 +251,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         - parameter channelId: A channel snowflake
         - returns: An optional containing a `DiscordGuild` if one was found.
     */
-    public func guildForChannel(_ channelId: String) -> DiscordGuild? {
+    public func guildForChannel(_ channelId: ChannelID) -> DiscordGuild? {
         return guilds.filter({ $0.1.channels[channelId] != nil }).map({ $0.1 }).first
     }
 
@@ -260,7 +260,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         - parameter channelId: The snowflake of the voice channel you would like to join
     */
-    open func joinVoiceChannel(_ channelId: String) {
+    open func joinVoiceChannel(_ channelId: ChannelID) {
         guard let guild = guildForChannel(channelId), let channel = guild.channels[channelId] as? DiscordGuildVoiceChannel else {
 
             return
@@ -282,7 +282,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         - parameter onGuild: The snowflake of the guild that you want to leave.
     */
-    open func leaveVoiceChannel(onGuild guildId: String) {
+    open func leaveVoiceChannel(onGuild guildId: GuildID) {
         voiceManager.leaveVoiceChannel(onGuild: guildId)
     }
 
@@ -292,7 +292,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
 
         - parameter on: The snowflake of the guild you wish to request all users.
     */
-    open func requestAllUsers(on guildId: String) {
+    open func requestAllUsers(on guildId: GuildID) {
         let requestObject: [String: Any] = [
             "guild_id": guildId,
             "query": "",
@@ -317,7 +317,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
                                                        onShard: 0)
     }
 
-    private func startVoiceConnection(_ guildId: String) {
+    private func startVoiceConnection(_ guildId: GuildID) {
         voiceManager.startVoiceConnection(guildId)
     }
 
@@ -470,11 +470,11 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         DefaultDiscordLogger.Logger.log("Handling channel delete", type: logType)
 
         guard let type = DiscordChannelType(rawValue: data["type"] as? Int ?? -1) else { return }
-        guard let channelId = data["id"] as? String else { return }
+        guard let channelId = Snowflake(data["id"] as? String) else { return }
 
         let removedChannel: DiscordChannel
 
-        if type == .text || type == .voice, let guildId = data["guild_id"] as? String,
+        if type == .text || type == .voice, let guildId = Snowflake(data["guild_id"] as? String),
            let guildChannel = guilds[guildId]?.channels.removeValue(forKey: channelId) {
             removedChannel = guildChannel
         } else if type == .direct || type == .groupDM, let direct = directChannels.removeValue(forKey: channelId) {
@@ -553,7 +553,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildDelete(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild delete", type: logType)
 
-        guard let guildId = data["id"] as? String else { return }
+        guard let guildId = Snowflake(data["id"] as? String) else { return }
         guard let removedGuild = guilds.removeValue(forKey: guildId) else { return }
 
         if let client = removedGuild.client {
@@ -579,7 +579,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildEmojiUpdate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild emoji update", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
         guard let emojis = data["emojis"] as? [[String: Any]] else { return }
 
         let discordEmojis = DiscordEmoji.emojisFromArray(emojis)
@@ -603,7 +603,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildMemberAdd(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild member add", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
 
         let guildMember = DiscordGuildMember(guildMemberObject: data, guildId: guild.id, guild: guild)
 
@@ -627,8 +627,8 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildMemberRemove(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild member remove", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
-        guard let user = data["user"] as? [String: Any], let id = user["id"] as? String else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
+        guard let user = data["user"] as? [String: Any], let id = Snowflake(user["id"] as? String) else { return }
 
         guild.memberCount -= 1
 
@@ -651,8 +651,8 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildMemberUpdate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild member update", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
-        guard let user = data["user"] as? [String: Any], let id = user["id"] as? String else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
+        guard let user = data["user"] as? [String: Any], let id = Snowflake(user["id"] as? String) else { return }
         guard let guildMember = guild.members[id]?.updateMember(data) else { return }
 
         DefaultDiscordLogger.Logger.verbose("Updated guild member: \(guildMember)", type: logType)
@@ -672,7 +672,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildMembersChunk(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild members chunk", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
         guard let members = data["members"] as? [[String: Any]] else { return }
 
         let guildMembers = DiscordGuildMember.guildMembersFromArray(members, withGuildId: guildId, guild: guild)
@@ -694,7 +694,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildRoleCreate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild role create", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
         guard let roleObject = data["role"] as? [String: Any] else { return }
         let role = DiscordRole(roleObject: roleObject)
 
@@ -717,8 +717,8 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildRoleRemove(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild role remove", type: logType)
 
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
-        guard let roleId = data["role_id"] as? String else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
+        guard let roleId = Snowflake(data["role_id"] as? String) else { return }
         guard let removedRole = guild.roles.removeValue(forKey: roleId) else { return }
 
         DefaultDiscordLogger.Logger.verbose("Removed role: \(removedRole)", type: logType)
@@ -739,7 +739,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         DefaultDiscordLogger.Logger.log("Handling guild role update", type: logType)
 
         // Functionally the same as adding
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
         guard let roleObject = data["role"] as? [String: Any] else { return }
         let role = DiscordRole(roleObject: roleObject)
 
@@ -762,7 +762,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleGuildUpdate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling guild update", type: logType)
 
-        guard let guildId = data["id"] as? String else { return }
+        guard let guildId = Snowflake(data["id"] as? String) else { return }
         guard let updatedGuild = guilds[guildId]?.updateGuild(fromGuildUpdate: data) else { return }
 
         DefaultDiscordLogger.Logger.verbose("Updated guild: \(updatedGuild)", type: logType)
@@ -818,8 +818,8 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
         - parameter with: The data from the event
     */
     open func handlePresenceUpdate(with data: [String: Any]) {
-        guard let guildId = data["guild_id"] as? String, let guild = guilds[guildId] else { return }
-        guard let user = data["user"] as? [String: Any], let userId = user["id"] as? String else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String), let guild = guilds[guildId] else { return }
+        guard let user = data["user"] as? [String: Any], let userId = Snowflake(user["id"] as? String) else { return }
 
         var presence = guild.presences[userId]
 
@@ -905,20 +905,20 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleVoiceStateUpdate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling voice state update", type: logType)
 
-        guard let guildId = data["guild_id"] as? String else { return }
+        guard let guildId = Snowflake(data["guild_id"] as? String) else { return }
 
         let state = DiscordVoiceState(voiceStateObject: data, guildId: guildId)
 
         DefaultDiscordLogger.Logger.verbose("Voice state: \(state)", type: logType)
 
-        if state.channelId == "" {
+        if state.channelId == 0 {
             guilds[guildId]?.voiceStates[state.userId] = nil
         } else {
             guilds[guildId]?.voiceStates[state.userId] = state
         }
 
         if state.userId == user?.id {
-            if state.channelId == "" {
+            if state.channelId == 0 {
                 voiceManager.protected { self.voiceManager.voiceStates[state.guildId] = nil }
             } else {
                 voiceManager.protected { self.voiceManager.voiceStates[state.guildId] = state }

--- a/Sources/SwiftDiscord/DiscordClientDelegate.swift
+++ b/Sources/SwiftDiscord/DiscordClientDelegate.swift
@@ -204,7 +204,7 @@ public protocol DiscordClientDelegate : class {
         - parameter didHandleGuildMemberChunk: The chunk of guild members that was handled.
         - parameter forGuild: The guild the members were added to.
     */
-    func client(_ client: DiscordClient, didHandleGuildMemberChunk chunk: DiscordLazyDictionary<String, DiscordGuildMember>,
+    func client(_ client: DiscordClient, didHandleGuildMemberChunk chunk: DiscordLazyDictionary<UserID, DiscordGuildMember>,
                 forGuild guild: DiscordGuild)
 
     /**
@@ -224,7 +224,7 @@ public protocol DiscordClientDelegate : class {
         - parameter didUpdateEmojis: The chunk of guild members that was handled.
         - parameter onGuild: The guild the emojis were updated on.
     */
-    func client(_ client: DiscordClient, didUpdateEmojis emojis: [String: DiscordEmoji],
+    func client(_ client: DiscordClient, didUpdateEmojis emojis: [EmojiID: DiscordEmoji],
                 onGuild guild: DiscordGuild)
 
     /**
@@ -305,7 +305,7 @@ public extension DiscordClientDelegate {
     func client(_ client: DiscordClient, isReadyToSendVoiceWithEngine engine: DiscordVoiceEngine) { }
 
     /// Default.
-    func client(_ client: DiscordClient, didHandleGuildMemberChunk chunk: DiscordLazyDictionary<String, DiscordGuildMember>,
+    func client(_ client: DiscordClient, didHandleGuildMemberChunk chunk: DiscordLazyDictionary<UserID, DiscordGuildMember>,
                 forGuild guild: DiscordGuild) { }
 
     /// Default.
@@ -313,7 +313,7 @@ public extension DiscordClientDelegate {
                 withData data: [String: Any]) { }
 
     /// Default.
-    func client(_ client: DiscordClient, didUpdateEmojis emojis: [String: DiscordEmoji],
+    func client(_ client: DiscordClient, didUpdateEmojis emojis: [EmojiID: DiscordEmoji],
                 onGuild guild: DiscordGuild) { }
 
     /// Default.

--- a/Sources/SwiftDiscord/DiscordClientSpec.swift
+++ b/Sources/SwiftDiscord/DiscordClientSpec.swift
@@ -59,14 +59,14 @@ public protocol DiscordClientSpec : class, DiscordVoiceManagerDelegate, DiscordS
 
 		- parameter channelId: The snowflake of the voice channel you would like to join
 	*/
-	func joinVoiceChannel(_ channelId: String)
+	func joinVoiceChannel(_ channelId: ChannelID)
 
 	/**
 		Leaves the currently connected voice channel.
 
 		- parameter onGuild: The snowflake of the guild whose voice channel you would like to leave.
 	*/
-	func leaveVoiceChannel(onGuild guildId: String)
+	func leaveVoiceChannel(onGuild guildId: GuildID)
 
 	/**
 		Requests all users from Discord for the guild specified. Use this when you need to get all users on a large
@@ -74,7 +74,7 @@ public protocol DiscordClientSpec : class, DiscordVoiceManagerDelegate, DiscordS
 
 		- parameter on: The snowflake of the guild you wish to request all users.
 	*/
-	func requestAllUsers(on guildId: String)
+	func requestAllUsers(on guildId: GuildID)
 
 	/**
 		Sets the user's presence.

--- a/Sources/SwiftDiscord/DiscordDMChannel.swift
+++ b/Sources/SwiftDiscord/DiscordDMChannel.swift
@@ -20,7 +20,7 @@ public struct DiscordDMChannel : DiscordTextChannel {
     // MARK: Properties
 
     /// The snowflake id of the channel.
-    public let id: String
+    public let id: ChannelID
 
     /// Whether this channel is private. Should always be true for DMChannels
     public var isPrivate: Bool { return true }
@@ -32,23 +32,23 @@ public struct DiscordDMChannel : DiscordTextChannel {
     public weak var client: DiscordClient?
 
     /// The snowflake id of the last received message on this channel.
-    public var lastMessageId: String
+    public var lastMessageId: MessageID
 
     init(dmObject: [String: Any]) {
         recipient = DiscordUser(userObject: dmObject.get("recipient", or: [String: Any]()))
-        id = dmObject.get("id", or: "")
-        lastMessageId = dmObject.get("last_message_id", or: "")
+        id = Snowflake(dmObject["id"] as? String) ?? 0
+        lastMessageId = Snowflake(dmObject["last_message_id"] as? String) ?? 0
     }
 
     init(dmReadyObject: [String: Any], client: DiscordClient? = nil) {
         recipient = DiscordUser(userObject: dmReadyObject.get("recipients", or: JSONArray())[0])
-        id = dmReadyObject.get("id", or: "")
-        lastMessageId = dmReadyObject.get("last_message_id", or: "")
+        id = Snowflake(dmReadyObject["id"] as? String) ?? 0
+        lastMessageId = Snowflake(dmReadyObject["last_message_id"] as? String) ?? 0
         self.client = client
     }
 
-    static func DMsfromArray(_ dmArray: [[String: Any]]) -> [String: DiscordDMChannel] {
-        var dms = [String: DiscordDMChannel]()
+    static func DMsfromArray(_ dmArray: [[String: Any]]) -> [ChannelID: DiscordDMChannel] {
+        var dms = [ChannelID: DiscordDMChannel]()
 
         for dm in dmArray {
             let dmChannel = DiscordDMChannel(dmObject: dm)
@@ -65,7 +65,7 @@ public struct DiscordGroupDMChannel : DiscordTextChannel {
     // MARK: Properties
 
     /// The snowflake id of the channel.
-    public let id: String
+    public let id: ChannelID
 
     /// Whether this channel is private. Should always be true for DMChannels
     public var isPrivate: Bool { return true }
@@ -77,15 +77,15 @@ public struct DiscordGroupDMChannel : DiscordTextChannel {
     public weak var client: DiscordClient?
 
     /// The snowflake id of the last received message on this channel.
-    public var lastMessageId: String
+    public var lastMessageId: MessageID
 
     /// The name of this group dm.
     public var name: String?
 
     init(dmReadyObject: [String: Any], client: DiscordClient? = nil) {
         recipients = dmReadyObject.get("recipients", or: JSONArray()).map(DiscordUser.init)
-        id = dmReadyObject.get("id", or: "")
-        lastMessageId = dmReadyObject.get("lastMessageId", or: "")
+        id = Snowflake(dmReadyObject["id"] as? String) ?? 0
+        lastMessageId = Snowflake(dmReadyObject["last_message_id"] as? String) ?? 0
         name = dmReadyObject["name"] as? String
         self.client = client
     }

--- a/Sources/SwiftDiscord/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/DiscordEndpoint.swift
@@ -50,85 +50,85 @@ public enum DiscordEndpoint: CustomStringConvertible {
 
     /* Channels */
     /// The base channel endpoint.
-    case channel(id: String)
+    case channel(id: ChannelID)
 
     // Messages
     /// The base channel messages endpoint.
-    case messages(channel: String)
+    case messages(channel: ChannelID)
 
     /// The channel bulk delete endpoint.
-    case bulkMessageDelete(channel: String)
+    case bulkMessageDelete(channel: ChannelID)
 
     /// The base channel message endpoint.
-    case channelMessage(channel: String, message: String)
+    case channelMessage(channel: ChannelID, message: MessageID)
 
     /// Same as channelMessage, separate for rate limiting purposes
-    case channelMessageDelete(channel: String, message: String)
+    case channelMessageDelete(channel: ChannelID, message: MessageID)
 
     /// The channel typing endpoint.
-    case typing(channel: String)
+    case typing(channel: ChannelID)
 
     // Permissions
     /// The base channel permissions endpoint.
-    case permissions(channel: String)
+    case permissions(channel: ChannelID)
 
     /// The channel permission endpoint.
-    case channelPermission(channel: String, overwrite: String)
+    case channelPermission(channel: ChannelID, overwrite: OverwriteID)
 
     // Invites
     /// The base endpoint for invites.
     case invites(code: String)
 
     /// The base endpoint for channel invites.
-    case channelInvites(channel: String)
+    case channelInvites(channel: ChannelID)
 
     // Pinned Messages
     /// The base endpoint for pinned channel messages.
-    case pins(channel: String)
+    case pins(channel: ChannelID)
 
     /// The channel pinned message endpoint.
-    case pinnedMessage(channel: String, message: String)
+    case pinnedMessage(channel: ChannelID, message: MessageID)
 
     // Webhooks
     /// The channel webhooks endpoint.
-    case channelWebhooks(channel: String)
+    case channelWebhooks(channel: ChannelID)
     /* End channels */
 
     /* Guilds */
     /// The base guild endpoint.
-    case guilds(id: String)
+    case guilds(id: GuildID)
 
     // Guild Channels
     /// The base endpoint for guild channels.
-    case guildChannels(guild: String)
+    case guildChannels(guild: GuildID)
 
     // Guild Members
     /// The base guild members endpoint.
-    case guildMembers(guild: String)
+    case guildMembers(guild: GuildID)
 
     /// The guild member endpoint.
-    case guildMember(guild: String, user: String)
+    case guildMember(guild: GuildID, user: UserID)
 
     /// The guild member roles enpoint.
-    case guildMemberRole(guild: String, user: String, role: String)
+    case guildMemberRole(guild: GuildID, user: UserID, role: RoleID)
 
     // Guild Bans
     /// The base guild bans endpoint.
-    case guildBans(guild: String)
+    case guildBans(guild: GuildID)
 
     /// The guild ban user endpoint.
-    case guildBanUser(guild: String, user: String)
+    case guildBanUser(guild: GuildID, user: UserID)
 
     // Guild Roles
     /// The base guild roles endpoint.
-    case guildRoles(guild: String)
+    case guildRoles(guild: GuildID)
 
     /// The guild role endpoint.
-    case guildRole(guild: String, role: String)
+    case guildRole(guild: GuildID, role: RoleID)
 
     // Webhooks
     /// The guilds webhooks endpoint.
-    case guildWebhooks(guild: String)
+    case guildWebhooks(guild: GuildID)
     /* End Guilds */
 
     /* User */
@@ -140,16 +140,16 @@ public enum DiscordEndpoint: CustomStringConvertible {
 
     /* Webhooks */
     /// The single webhook endpoint.
-    case webhook(id: String)
+    case webhook(id: WebhookID)
 
     /// The single webhook with token endpoint.
-    case webhookWithToken(id: String, token: String)
+    case webhookWithToken(id: WebhookID, token: String)
 
     /// A slack compatible webhook.
-    case webhookSlack(id: String, token: String)
+    case webhookSlack(id: WebhookID, token: String)
 
     /// A GitHub compatible webhook.
-    case webhookGithub(id: String, token: String)
+    case webhookGithub(id: WebhookID, token: String)
     /* End Webhooks */
 
     var combined: String {

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Channels.swift
@@ -19,7 +19,7 @@ import Foundation
 
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
-    public func addPinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
+    public func addPinnedMessage(_ messageId: MessageID, on channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .pinnedMessage(channel: channelId, message: messageId),
                                    token: token,
                                    requestInfo: .put(content: nil),
@@ -27,8 +27,8 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func bulkDeleteMessages(_ messages: [String], on channelId: String, callback: ((Bool) -> ())? = nil) {
-        guard let contentData = JSON.encodeJSONData(["messages": messages]) else { return }
+    public func bulkDeleteMessages(_ messages: [MessageID], on channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
+        guard let contentData = JSON.encodeJSONData(["messages": messages.map({ $0.description })]) else { return }
         rateLimiter.executeRequest(endpoint: .bulkMessageDelete(channel: channelId),
                                    token: token,
                                    requestInfo: .post(content: (contentData, type: .json)),
@@ -36,7 +36,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func createInvite(for channelId: String, options: [DiscordEndpoint.Options.CreateInvite],
+    public func createInvite(for channelId: ChannelID, options: [DiscordEndpoint.Options.CreateInvite],
                              callback: @escaping (DiscordInvite?) -> ()) {
         var inviteJSON: [String: Any] = [:]
 
@@ -71,7 +71,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func deleteChannel(_ channelId: String, callback: ((Bool) -> ())? = nil) {
+    public func deleteChannel(_ channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .channel(id: channelId),
                                    token: token,
                                    requestInfo: .delete,
@@ -79,7 +79,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func deleteChannelPermission(_ overwriteId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
+    public func deleteChannelPermission(_ overwriteId: OverwriteID, on channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .channelPermission(channel: channelId, overwrite: overwriteId),
                                    token: token,
                                    requestInfo: .delete,
@@ -87,7 +87,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func deleteMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
+    public func deleteMessage(_ messageId: MessageID, on channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .channelMessageDelete(channel: channelId, message: messageId),
                                    token: token,
                                    requestInfo: .delete,
@@ -95,7 +95,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func deletePinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())? = nil) {
+    public func deletePinnedMessage(_ messageId: MessageID, on channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .pinnedMessage(channel: channelId, message: messageId),
                                    token: token,
                                    requestInfo: .delete,
@@ -103,7 +103,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func editChannelPermission(_ permissionOverwrite: DiscordPermissionOverwrite, on channelId: String,
+    public func editChannelPermission(_ permissionOverwrite: DiscordPermissionOverwrite, on channelId: ChannelID,
                                       callback: ((Bool) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(permissionOverwrite.json) else { return }
 
@@ -114,7 +114,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getInvites(for channelId: String, callback: @escaping ([DiscordInvite]) -> ()) {
+    public func getInvites(for channelId: ChannelID, callback: @escaping ([DiscordInvite]) -> ()) {
 
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(invites)? = JSON.jsonFromResponse(data: data, response: response) else {
@@ -131,7 +131,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func editMessage(_ messageId: String, on channelId: String, content: String,
+    public func editMessage(_ messageId: MessageID, on channelId: ChannelID, content: String,
                             callback: ((DiscordMessage?) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(["content": content]) else { return }
 
@@ -149,7 +149,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getChannel(_ channelId: String, callback: @escaping (DiscordChannel?) -> ()) {
+    public func getChannel(_ channelId: ChannelID, callback: @escaping (DiscordChannel?) -> ()) {
         let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .object(channel)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
@@ -164,18 +164,18 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getMessages(for channelId: String, options: [DiscordEndpoint.Options.GetMessage] = [],
+    public func getMessages(for channelId: ChannelID, options: [DiscordEndpoint.Options.GetMessage] = [],
                             callback: @escaping ([DiscordMessage]) -> ()) {
         var getParams: [String: String] = [:]
 
         for option in options {
             switch option {
             case let .after(message):
-                getParams["after"] = String(message.id)
+                getParams["after"] = String(describing: message.id)
             case let .around(message):
-                getParams["around"] = String(message.id)
+                getParams["around"] = String(describing: message.id)
             case let .before(message):
-                getParams["before"] = String(message.id)
+                getParams["before"] = String(describing: message.id)
             case let .limit(number):
                 getParams["limit"] = String(number)
             }
@@ -195,7 +195,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getPinnedMessages(for channelId: String, callback: @escaping ([DiscordMessage]) -> ()) {
+    public func getPinnedMessages(for channelId: ChannelID, callback: @escaping ([DiscordMessage]) -> ()) {
         let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .array(messages)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
@@ -210,7 +210,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func modifyChannel(_ channelId: String, options: [DiscordEndpoint.Options.ModifyChannel],
+    public func modifyChannel(_ channelId: ChannelID, options: [DiscordEndpoint.Options.ModifyChannel],
                               callback: ((DiscordGuildChannel?) -> ())? = nil) {
         var modifyJSON: [String: Any] = [:]
 
@@ -245,7 +245,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation.
-    public func sendMessage(_ message: DiscordMessage, to channelId: String,
+    public func sendMessage(_ message: DiscordMessage, to channelId: ChannelID,
                             callback: ((DiscordMessage?) -> ())? = nil) {
         let requestInfo: DiscordEndpoint.EndpointRequest
         switch message.createDataForSending() {
@@ -271,7 +271,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func triggerTyping(on channelId: String, callback: ((Bool) -> ())? = nil) {
+    public func triggerTyping(on channelId: ChannelID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .typing(channel: channelId),
                                    token: token,
                                    requestInfo: .post(content: nil),

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Guilds.swift
@@ -19,7 +19,7 @@ import Foundation
 
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
-    public func addGuildMemberRole(_ roleId: String, to userId: String, on guildId: String,
+    public func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID,
                                    callback: ((Bool) -> ())?) {
         rateLimiter.executeRequest(endpoint: .guildMemberRole(guild: guildId, user: userId, role: roleId),
                                    token: token,
@@ -28,7 +28,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func createGuildChannel(on guildId: String, options: [DiscordEndpoint.Options.GuildCreateChannel],
+    public func createGuildChannel(on guildId: GuildID, options: [DiscordEndpoint.Options.GuildCreateChannel],
                                    callback: ((DiscordGuildChannel?) -> ())? = nil) {
         var createJSON: [String: Any] = [:]
 
@@ -65,7 +65,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func createGuildRole(on guildId: String, withOptions options: [DiscordEndpoint.Options.CreateRole] = [],
+    public func createGuildRole(on guildId: GuildID, withOptions options: [DiscordEndpoint.Options.CreateRole] = [],
                                 callback: @escaping (DiscordRole?) -> ()) {
         var roleData: [String: Any] = [:]
 
@@ -105,7 +105,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func deleteGuild(_ guildId: String, callback: ((DiscordGuild?) -> ())? = nil) {
+    public func deleteGuild(_ guildId: GuildID, callback: ((DiscordGuild?) -> ())? = nil) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(guild)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)
@@ -122,7 +122,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getGuildBans(for guildId: String, callback: @escaping ([DiscordBan]) -> ()) {
+    public func getGuildBans(for guildId: GuildID, callback: @escaping ([DiscordBan]) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(bans)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
@@ -138,7 +138,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getGuildChannels(_ guildId: String, callback: @escaping ([DiscordGuildChannel]) -> ()) {
+    public func getGuildChannels(_ guildId: GuildID, callback: @escaping ([DiscordGuildChannel]) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(channels)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
@@ -153,7 +153,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getGuildMember(by id: String, on guildId: String, callback: @escaping (DiscordGuildMember?) -> ()) {
+    public func getGuildMember(by id: UserID, on guildId: GuildID, callback: @escaping (DiscordGuildMember?) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(member)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
@@ -168,7 +168,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getGuildMembers(on guildId: String, options: [DiscordEndpoint.Options.GuildGetMembers],
+    public func getGuildMembers(on guildId: GuildID, options: [DiscordEndpoint.Options.GuildGetMembers],
                                 callback: @escaping ([DiscordGuildMember]) -> ()) {
         var getParams: [String: String] = [:]
 
@@ -197,7 +197,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getGuildRoles(for guildId: String, callback: @escaping ([DiscordRole]) -> ()) {
+    public func getGuildRoles(for guildId: GuildID, callback: @escaping ([DiscordRole]) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(roles)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
@@ -212,7 +212,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func guildBan(userId: String, on guildId: String, deleteMessageDays: Int = 7,
+    public func guildBan(userId: UserID, on guildId: GuildID, deleteMessageDays: Int = 7,
                          callback: ((Bool) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(["delete-message-days": deleteMessageDays]) else { return }
 
@@ -223,7 +223,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
         }
 
     /// Default implementation
-    public func modifyGuild(_ guildId: String, options: [DiscordEndpoint.Options.ModifyGuild],
+    public func modifyGuild(_ guildId: GuildID, options: [DiscordEndpoint.Options.ModifyGuild],
                             callback: ((DiscordGuild?) -> ())? = nil) {
         var modifyJSON: [String: Any] = [:]
 
@@ -268,7 +268,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func modifyGuildChannelPositions(on guildId: String, channelPositions: [[String: Any]],
+    public func modifyGuildChannelPositions(on guildId: GuildID, channelPositions: [[String: Any]],
                                             callback: (([DiscordGuildChannel]) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(channelPositions) else { return }
 
@@ -288,7 +288,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    func modifyGuildMember(_ id: String, on guildId: String, options: [DiscordEndpoint.Options.ModifyMember],
+    func modifyGuildMember(_ id: UserID, on guildId: GuildID, options: [DiscordEndpoint.Options.ModifyMember],
                            callback: ((Bool) -> ())? = nil) {
         var patchParams: [String: Any] = [:]
 
@@ -314,7 +314,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func modifyGuildRole(_ role: DiscordRole, on guildId: String, callback: ((DiscordRole?) -> ())? = nil) {
+    public func modifyGuildRole(_ role: DiscordRole, on guildId: GuildID, callback: ((DiscordRole?) -> ())? = nil) {
         guard let contentData = JSON.encodeJSONData(role.json) else { return }
 
         let requestCallback: DiscordRequestCallback = { data, response, error in
@@ -331,7 +331,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func removeGuildBan(for userId: String, on guildId: String, callback: ((Bool) -> ())? = nil) {
+    public func removeGuildBan(for userId: UserID, on guildId: GuildID, callback: ((Bool) -> ())? = nil) {
         DefaultDiscordLogger.Logger.log("Unbanning \(userId) on \(guildId)", type: "DiscordEndpointGuild")
 
         rateLimiter.executeRequest(endpoint: .guildBanUser(guild: guildId, user: userId),
@@ -341,7 +341,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation.
-    public func removeGuildMemberRole(_ roleId: String, from userId: String, on guildId: String,
+    public func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID,
                                       callback: ((Bool) -> ())?) {
         rateLimiter.executeRequest(endpoint: .guildMemberRole(guild: guildId, user: userId, role: roleId),
                                    token: token,
@@ -350,7 +350,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func removeGuildRole(_ roleId: String, on guildId: String, callback: ((DiscordRole?) -> ())? = nil) {
+    public func removeGuildRole(_ roleId: RoleID, on guildId: GuildID, callback: ((DiscordRole?) -> ())? = nil) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(role)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil)

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+User.swift
@@ -19,7 +19,7 @@ import Foundation
 
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
-    public func createDM(with: String, callback: @escaping (DiscordDMChannel?) -> ()) {
+    public func createDM(with: UserID, callback: @escaping (DiscordDMChannel?) -> ()) {
         guard let contentData = JSON.encodeJSONData(["recipient_id": with]) else { return }
 
         let requestCallback: DiscordRequestCallback = { data, response, error in
@@ -36,7 +36,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getDMs(callback: @escaping ([String: DiscordDMChannel]) -> ()) {
+    public func getDMs(callback: @escaping ([ChannelID: DiscordDMChannel]) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(channels)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([:])
@@ -53,7 +53,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getGuilds(callback: @escaping ([String: DiscordUserGuild]) -> ()) {
+    public func getGuilds(callback: @escaping ([GuildID: DiscordUserGuild]) -> ()) {
         let requestCallback: DiscordRequestCallback = {data, response, error in
             guard case let .array(guilds)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([:])

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer+Webhooks.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer+Webhooks.swift
@@ -19,7 +19,7 @@ import Foundation
 
 public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     /// Default implementation
-    public func createWebhook(forChannel channelId: String, options: [DiscordEndpoint.Options.WebhookOption],
+    public func createWebhook(forChannel channelId: ChannelID, options: [DiscordEndpoint.Options.WebhookOption],
                               callback: @escaping (DiscordWebhook?) -> () = {_ in }) {
         var createJSON: [String: Any] = [:]
 
@@ -50,7 +50,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func deleteWebhook(_ webhookId: String, callback: ((Bool) -> ())? = nil) {
+    public func deleteWebhook(_ webhookId: WebhookID, callback: ((Bool) -> ())? = nil) {
         rateLimiter.executeRequest(endpoint: .webhook(id: webhookId),
                                    token: token,
                                    requestInfo: .delete,
@@ -58,7 +58,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getWebhook(_ webhookId: String, callback: @escaping (DiscordWebhook?) -> ()) {
+    public func getWebhook(_ webhookId: WebhookID, callback: @escaping (DiscordWebhook?) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(webhook)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback(nil)
@@ -73,7 +73,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getWebhooks(forChannel channelId: String, callback: @escaping ([DiscordWebhook]) -> ()) {
+    public func getWebhooks(forChannel channelId: ChannelID, callback: @escaping ([DiscordWebhook]) -> ()) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .array(webhooks)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback([])
@@ -88,7 +88,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getWebhooks(forGuild guildId: String, callback: @escaping ([DiscordWebhook]) -> ()) {
+    public func getWebhooks(forGuild guildId: GuildID, callback: @escaping ([DiscordWebhook]) -> ()) {
         DefaultDiscordLogger.Logger.debug("Getting webhooks for guild: \(guildId)", type: "DiscordEndpointWebhooks")
 
         let requestCallback: DiscordRequestCallback = { data, response, error in
@@ -105,7 +105,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func modifyWebhook(_ webhookId: String, options: [DiscordEndpoint.Options.WebhookOption],
+    public func modifyWebhook(_ webhookId: WebhookID, options: [DiscordEndpoint.Options.WebhookOption],
                               callback: @escaping (DiscordWebhook?) -> () = {_ in }) {
         var createJSON: [String: Any] = [:]
 

--- a/Sources/SwiftDiscord/DiscordEndpointConsumer.swift
+++ b/Sources/SwiftDiscord/DiscordEndpointConsumer.swift
@@ -41,7 +41,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The channel that we are adding on
         - parameter callback: An optional callback indicating whether the pinned message was added.
     */
-    func addPinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())?)
+    func addPinnedMessage(_ messageId: MessageID, on channelId: ChannelID, callback: ((Bool) -> ())?)
 
     /**
         Deletes a bunch of messages at once.
@@ -50,7 +50,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The channel that we are deleting on
         - parameter callback: An optional callback indicating whether the messages were deleted.
     */
-    func bulkDeleteMessages(_ messages: [String], on channelId: String, callback: ((Bool) -> ())?)
+    func bulkDeleteMessages(_ messages: [MessageID], on channelId: ChannelID, callback: ((Bool) -> ())?)
 
     /**
         Creates an invite for a channel/guild.
@@ -59,7 +59,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: An array of `DiscordEndpointOptions.CreateInvite` options
         - parameter callback: The callback function. Takes an optional `DiscordInvite`
     */
-    func createInvite(for channelId: String, options: [DiscordEndpoint.Options.CreateInvite],
+    func createInvite(for channelId: ChannelID, options: [DiscordEndpoint.Options.CreateInvite],
                       callback: @escaping (DiscordInvite?) -> ())
 
     /**
@@ -68,7 +68,7 @@ public protocol DiscordEndpointConsumer {
         - parameter channelId: The snowflake id of the channel
         - parameter callback: An optional callback indicating whether the channel was deleted.
     */
-    func deleteChannel(_ channelId: String, callback: ((Bool) -> ())?)
+    func deleteChannel(_ channelId: ChannelID, callback: ((Bool) -> ())?)
 
     /**
         Deletes a channel permission
@@ -77,7 +77,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The channel that we are deleting on
         - parameter callback: An optional callback indicating whether the permission was deleted.
     */
-    func deleteChannelPermission(_ overwriteId: String, on channelId: String, callback: ((Bool) -> ())?)
+    func deleteChannelPermission(_ overwriteId: OverwriteID, on channelId: ChannelID, callback: ((Bool) -> ())?)
 
     /**
         Deletes a single message
@@ -86,7 +86,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The channel that we are deleting on
         - parameter callback: An optional callback indicating whether the message was deleted.
     */
-    func deleteMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())?)
+    func deleteMessage(_ messageId: MessageID, on channelId: ChannelID, callback: ((Bool) -> ())?)
 
     /**
         Unpins a message.
@@ -95,7 +95,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The channel that we are unpinning on
         - parameter callback: An optional callback indicating whether the message was unpinned.
     */
-    func deletePinnedMessage(_ messageId: String, on channelId: String, callback: ((Bool) -> ())?)
+    func deletePinnedMessage(_ messageId: MessageID, on channelId: ChannelID, callback: ((Bool) -> ())?)
 
     /**
         Gets the specified channel.
@@ -103,7 +103,7 @@ public protocol DiscordEndpointConsumer {
         - parameter channelId: The snowflake id of the channel
         - parameter callback: The callback function containing an optional `DiscordChannel`
     */
-    func getChannel(_ channelId: String, callback: @escaping (DiscordChannel?) -> ())
+    func getChannel(_ channelId: ChannelID, callback: @escaping (DiscordChannel?) -> ())
 
     /**
         Edits a message
@@ -113,7 +113,7 @@ public protocol DiscordEndpointConsumer {
         - parameter content: The new content of the message
         - parameter callback: An optional callback containing the edited message, if successful.
     */
-    func editMessage(_ messageId: String, on channelId: String, content: String, callback: ((DiscordMessage?) -> ())?)
+    func editMessage(_ messageId: MessageID, on channelId: ChannelID, content: String, callback: ((DiscordMessage?) -> ())?)
 
     /**
         Edits the specified permission overwrite.
@@ -122,7 +122,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The channel that we are editing on
         - parameter callback: An optional callback indicating whether the edit was successful.
     */
-    func editChannelPermission(_ permissionOverwrite: DiscordPermissionOverwrite, on channelId: String,
+    func editChannelPermission(_ permissionOverwrite: DiscordPermissionOverwrite, on channelId: ChannelID,
                                callback: ((Bool) -> ())?)
 
     /**
@@ -131,7 +131,7 @@ public protocol DiscordEndpointConsumer {
         - parameter for: The channel that we are getting on
         - parameter callback: The callback function, taking an array of `DiscordInvite`
     */
-    func getInvites(for channelId: String, callback: @escaping ([DiscordInvite]) -> ())
+    func getInvites(for channelId: ChannelID, callback: @escaping ([DiscordInvite]) -> ())
 
     /**
         Gets a group of messages according to the specified options.
@@ -140,7 +140,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: An array of `DiscordEndpointOptions.GetMessage` options
         - parameter callback: The callback function, taking an array of `DiscordMessages`
     */
-    func getMessages(for channel: String, options: [DiscordEndpoint.Options.GetMessage],
+    func getMessages(for channel: ChannelID, options: [DiscordEndpoint.Options.GetMessage],
                      callback: @escaping ([DiscordMessage]) -> ())
 
     /**
@@ -150,7 +150,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: An array of `DiscordEndpointOptions.ModifyChannel` options
         - parameter callback: An optional callback containing the edited guild channel, if successful.
     */
-    func modifyChannel(_ channelId: String, options: [DiscordEndpoint.Options.ModifyChannel],
+    func modifyChannel(_ channelId: ChannelID, options: [DiscordEndpoint.Options.ModifyChannel],
                        callback: ((DiscordGuildChannel?) -> ())?)
 
     /**
@@ -159,7 +159,7 @@ public protocol DiscordEndpointConsumer {
         - parameter for: The channel that we are getting the pinned messages for
         - parameter callback: The callback function, taking an array of `DiscordMessages`
     */
-    func getPinnedMessages(for channelId: String, callback: @escaping ([DiscordMessage]) -> ())
+    func getPinnedMessages(for channelId: ChannelID, callback: @escaping ([DiscordMessage]) -> ())
 
     /**
         Sends a message with an optional file and embed to the specified channel.
@@ -189,7 +189,7 @@ public protocol DiscordEndpointConsumer {
         - parameter to: The snowflake id of the channel to send to.
         - parameter callback: An optional callback containing the message, if successful.
     */
-    func sendMessage(_ message: DiscordMessage, to channelId: String, callback: ((DiscordMessage?) -> ())?)
+    func sendMessage(_ message: DiscordMessage, to channelId: ChannelID, callback: ((DiscordMessage?) -> ())?)
 
     /**
         Triggers typing on the specified channel.
@@ -197,7 +197,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The snowflake id of the channel to send to
         - parameter callback: An optional callback indicating whether typing was triggered.
     */
-    func triggerTyping(on channelId: String, callback: ((Bool) -> ())?)
+    func triggerTyping(on channelId: ChannelID, callback: ((Bool) -> ())?)
 
     // MARK: Guilds
 
@@ -210,7 +210,7 @@ public protocol DiscordEndpointConsumer {
         - parameter with: The token to authenticate to Discord with.
         - parameter callback: An optional callback indicating whether the role was added successfully.
     */
-    func addGuildMemberRole(_ roleId: String, to userId: String, on guildId: String, callback: ((Bool) -> ())?)
+    func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, callback: ((Bool) -> ())?)
 
     /**
         Creates a guild channel.
@@ -219,7 +219,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: An array of `DiscordEndpointOptions.GuildCreateChannel` options
         - parameter callback: An optional callback containing the new channel, if successful.
     */
-    func createGuildChannel(on guildId: String, options: [DiscordEndpoint.Options.GuildCreateChannel],
+    func createGuildChannel(on guildId: GuildID, options: [DiscordEndpoint.Options.GuildCreateChannel],
                             callback: ((DiscordGuildChannel?) -> ())?)
 
     /**
@@ -229,7 +229,7 @@ public protocol DiscordEndpointConsumer {
         - parameter withOptions: The options for the new role. Optional in the default implementation.
         - parameter callback: The callback function, taking an optional `DiscordRole`.
     */
-    func createGuildRole(on guildId: String, withOptions options: [DiscordEndpoint.Options.CreateRole],
+    func createGuildRole(on guildId: GuildID, withOptions options: [DiscordEndpoint.Options.CreateRole],
                          callback: @escaping (DiscordRole?) -> ())
 
     /**
@@ -238,7 +238,7 @@ public protocol DiscordEndpointConsumer {
         - parameter guildId: The snowflake id of the guild
         - parameter callback: An optional callback containing the deleted guild, if successful.
     */
-    func deleteGuild(_ guildId: String, callback: ((DiscordGuild?) -> ())?)
+    func deleteGuild(_ guildId: GuildID, callback: ((DiscordGuild?) -> ())?)
 
     /**
         Gets the bans on a guild.
@@ -246,7 +246,7 @@ public protocol DiscordEndpointConsumer {
         - parameter for: The snowflake id of the guild
         - parameter callback: The callback function, taking an array of `DiscordBan`
     */
-    func getGuildBans(for guildId: String, callback: @escaping ([DiscordBan]) -> ())
+    func getGuildBans(for guildId: GuildID, callback: @escaping ([DiscordBan]) -> ())
 
     /**
         Gets the channels on a guild.
@@ -254,7 +254,7 @@ public protocol DiscordEndpointConsumer {
         - parameter guildId: The snowflake id of the guild
         - parameter callback: The callback function, taking an array of `DiscordGuildChannel`
     */
-    func getGuildChannels(_ guildId: String, callback: @escaping ([DiscordGuildChannel]) -> ())
+    func getGuildChannels(_ guildId: GuildID, callback: @escaping ([DiscordGuildChannel]) -> ())
 
     /**
         Gets the specified guild member.
@@ -263,7 +263,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The snowflake id of the guild
         - parameter callback: The callback function containing an optional `DiscordGuildMember`
     */
-    func getGuildMember(by id: String, on guildId: String, callback: @escaping (DiscordGuildMember?) -> ())
+    func getGuildMember(by id: UserID, on guildId: GuildID, callback: @escaping (DiscordGuildMember?) -> ())
 
     /**
         Gets the members on a guild.
@@ -272,7 +272,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: An array of `DiscordEndpointOptions.GuildGetMembers` options
         - parameter callback: The callback function, taking an array of `DiscordGuildMember`
     */
-    func getGuildMembers(on guildId: String, options: [DiscordEndpoint.Options.GuildGetMembers],
+    func getGuildMembers(on guildId: GuildID, options: [DiscordEndpoint.Options.GuildGetMembers],
                          callback: @escaping ([DiscordGuildMember]) -> ())
 
     /**
@@ -281,7 +281,7 @@ public protocol DiscordEndpointConsumer {
         - parameter for: The snowflake id of the guild
         - parameter callback: The callback function, taking an array of `DiscordRole`
     */
-    func getGuildRoles(for guildId: String, callback: @escaping ([DiscordRole]) -> ())
+    func getGuildRoles(for guildId: GuildID, callback: @escaping ([DiscordRole]) -> ())
 
     /**
         Creates a guild ban.
@@ -291,7 +291,7 @@ public protocol DiscordEndpointConsumer {
         - parameter deleteMessageDays: The number of days to delete this user's messages
         - parameter callback: An optional callback indicating whether the ban was successful.
     */
-    func guildBan(userId: String, on guildId: String, deleteMessageDays: Int, callback: ((Bool) -> ())?)
+    func guildBan(userId: UserID, on guildId: GuildID, deleteMessageDays: Int, callback: ((Bool) -> ())?)
 
     /**
         Modifies the specified guild.
@@ -300,7 +300,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: An array of `DiscordEndpointOptions.ModifyGuild` options
         - parameter callback: An optional callback containing the modified guild, if successful.
     */
-    func modifyGuild(_ guildId: String, options: [DiscordEndpoint.Options.ModifyGuild],
+    func modifyGuild(_ guildId: GuildID, options: [DiscordEndpoint.Options.ModifyGuild],
                      callback: ((DiscordGuild?) -> ())?)
 
     /**
@@ -311,7 +311,7 @@ public protocol DiscordEndpointConsumer {
                                       in the form `["id": channelId, "position": position]`
         - parameter callback: An optional callback containing the modified channels, if successful.
     */
-    func modifyGuildChannelPositions(on guildId: String, channelPositions: [[String: Any]],
+    func modifyGuildChannelPositions(on guildId: GuildID, channelPositions: [[String: Any]],
                                      callback: (([DiscordGuildChannel]) -> ())?)
 
     /**
@@ -322,7 +322,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: The options for this member.
         - parameter callback: The callback function, indicating whether the modify succeeded.
     */
-    func modifyGuildMember(_ id: String, on guildId: String, options: [DiscordEndpoint.Options.ModifyMember],
+    func modifyGuildMember(_ id: UserID, on guildId: GuildID, options: [DiscordEndpoint.Options.ModifyMember],
                            callback: ((Bool) -> ())?)
 
     /**
@@ -332,7 +332,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The guild that we are editing on
         - parameter callback: An optional callback containing the modified role, if successful.
     */
-    func modifyGuildRole(_ role: DiscordRole, on guildId: String, callback: ((DiscordRole?) -> ())?)
+    func modifyGuildRole(_ role: DiscordRole, on guildId: GuildID, callback: ((DiscordRole?) -> ())?)
 
     /**
         Removes a guild ban.
@@ -341,7 +341,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The snowflake id of the guild
         - parameter callback: An optional callback indicating whether the ban was successfully removed.
     */
-    func removeGuildBan(for userId: String, on guildId: String, callback: ((Bool) -> ())?)
+    func removeGuildBan(for userId: UserID, on guildId: GuildID, callback: ((Bool) -> ())?)
 
     /**
         Removes a role from a guild member.
@@ -352,7 +352,7 @@ public protocol DiscordEndpointConsumer {
         - parameter with: The token to authenticate to Discord with.
         - parameter callback: An optional callback indicating whether the role was removed successfully.
     */
-    func removeGuildMemberRole(_ roleId: String, from userId: String, on guildId: String, callback: ((Bool) -> ())?)
+    func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, callback: ((Bool) -> ())?)
 
     /**
         Removes a guild role.
@@ -361,7 +361,7 @@ public protocol DiscordEndpointConsumer {
         - parameter on: The snowflake id of the guild
         - parameter callback: An optional callback containing the removed role, if successful.
     */
-    func removeGuildRole(_ roleId: String, on guildId: String, callback: ((DiscordRole?) -> ())?)
+    func removeGuildRole(_ roleId: RoleID, on guildId: GuildID, callback: ((DiscordRole?) -> ())?)
 
     // MARK: Webhooks
 
@@ -372,7 +372,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: The options for this webhook
         - parameter callback: A callback that returns the webhook created, if successful.
     */
-    func createWebhook(forChannel channelId: String, options: [DiscordEndpoint.Options.WebhookOption],
+    func createWebhook(forChannel channelId: ChannelID, options: [DiscordEndpoint.Options.WebhookOption],
                        callback: @escaping (DiscordWebhook?) -> ())
 
     /**
@@ -381,7 +381,7 @@ public protocol DiscordEndpointConsumer {
         - parameter webhookId: The id of the webhook
         - paramter callback: An optional callback function that indicates whether the delete was successful
     */
-    func deleteWebhook(_ webhookId: String, callback: ((Bool) -> ())?)
+    func deleteWebhook(_ webhookId: WebhookID, callback: ((Bool) -> ())?)
 
     /**
         Gets the specified webhook.
@@ -389,7 +389,7 @@ public protocol DiscordEndpointConsumer {
         - parameter webhookId: The snowflake id of the webhook
         - parameter callback: The callback function containing an optional `DiscordToken`
     */
-    func getWebhook(_ webhookId: String, callback: @escaping (DiscordWebhook?) -> ())
+    func getWebhook(_ webhookId: WebhookID, callback: @escaping (DiscordWebhook?) -> ())
 
     /**
         Gets the webhooks for a specified channel.
@@ -397,7 +397,7 @@ public protocol DiscordEndpointConsumer {
         - parameter forChannel: The snowflake id of the channel.
         - parameter callback: The callback function taking an array of `DiscordWebhook`s
     */
-    func getWebhooks(forChannel channelId: String, callback: @escaping ([DiscordWebhook]) -> ())
+    func getWebhooks(forChannel channelId: ChannelID, callback: @escaping ([DiscordWebhook]) -> ())
 
     /**
         Gets the webhooks for a specified guild.
@@ -405,7 +405,7 @@ public protocol DiscordEndpointConsumer {
         - parameter forGuild: The snowflake id of the guild.
         - parameter callback: The callback function taking an array of `DiscordWebhook`s
     */
-    func getWebhooks(forGuild guildId: String, callback: @escaping ([DiscordWebhook]) -> ())
+    func getWebhooks(forGuild guildId: GuildID, callback: @escaping ([DiscordWebhook]) -> ())
 
     /**
         Modifies a webhook.
@@ -414,7 +414,7 @@ public protocol DiscordEndpointConsumer {
         - parameter options: The options for this webhook
         - parameter callback: A callback that returns the updated webhook, if successful.
     */
-    func modifyWebhook(_ webhookId: String, options: [DiscordEndpoint.Options.WebhookOption],
+    func modifyWebhook(_ webhookId: WebhookID, options: [DiscordEndpoint.Options.WebhookOption],
                        callback: @escaping (DiscordWebhook?) -> ())
 
     // MARK: Invites
@@ -452,7 +452,7 @@ public protocol DiscordEndpointConsumer {
         - parameter user: Our snowflake id
         - parameter callback: The callback function. Takes an optional `DiscordDMChannel`
     */
-    func createDM(with: String, callback: @escaping (DiscordDMChannel?) -> ())
+    func createDM(with: UserID, callback: @escaping (DiscordDMChannel?) -> ())
 
     /**
         Gets the direct message channels for a user.
@@ -461,7 +461,7 @@ public protocol DiscordEndpointConsumer {
         - parameter callback: The callback function, taking a dictionary of `DiscordDMChannel` associated by
                               the recipient's id
     */
-    func getDMs(callback: @escaping ([String: DiscordDMChannel]) -> ())
+    func getDMs(callback: @escaping ([ChannelID: DiscordDMChannel]) -> ())
 
     /**
         Gets guilds the user is in.
@@ -469,7 +469,7 @@ public protocol DiscordEndpointConsumer {
         - parameter user: Our snowflake id
         - parameter callback: The callback function, taking a dictionary of `DiscordUserGuild` associated by guild id
     */
-    func getGuilds(callback: @escaping ([String: DiscordUserGuild]) -> ())
+    func getGuilds(callback: @escaping ([ChannelID: DiscordUserGuild]) -> ())
 
     // MARK: Misc
 

--- a/Sources/SwiftDiscord/DiscordGuildChannel.swift
+++ b/Sources/SwiftDiscord/DiscordGuildChannel.swift
@@ -18,7 +18,7 @@
 /// Protocol that declares a type will be a Discord guild channel.
 public protocol DiscordGuildChannel : DiscordChannel {
     /// The snowflake id of the guild this channel is on.
-    var guildId: String { get }
+    var guildId: GuildID { get }
     
     /// The name of this channel.
     var name: String { get }
@@ -27,7 +27,7 @@ public protocol DiscordGuildChannel : DiscordChannel {
     var position: Int { get }
 
     /// The permissions specific to this channel.
-    var permissionOverwrites: [String: DiscordPermissionOverwrite] { get }
+    var permissionOverwrites: [OverwriteID: DiscordPermissionOverwrite] { get }
 }
 
 extension DiscordGuildChannel {
@@ -138,8 +138,8 @@ func guildChannelFromObject(_ channelObject: [String: Any], client: DiscordClien
 }
 
 func guildChannelsFromArray(_ guildChannelArray: [[String: Any]], client: DiscordClient? = nil)
-    -> [String: DiscordGuildChannel] {
-        var guildChannels = [String: DiscordGuildChannel]()
+    -> [ChannelID: DiscordGuildChannel] {
+        var guildChannels = [ChannelID: DiscordGuildChannel]()
 
         for guildChannelObject in guildChannelArray {
             let guildChannel = guildChannelFromObject(guildChannelObject)
@@ -154,13 +154,13 @@ public struct DiscordGuildTextChannel : DiscordTextChannel, DiscordGuildChannel 
     // MARK: Guild Text Channel Properties
 
     /// The snowflake id of the channel.
-    public let id: String
+    public let id: ChannelID
 
     /// Whether this is a private channel. Should always be false for GuildChannels.
     public var isPrivate: Bool { return false }
 
     /// The snowflake id of the guild this channel is on.
-    public let guildId: String
+    public let guildId: GuildID
 
     /// Reference to the client.
     public weak var client: DiscordClient?
@@ -168,13 +168,13 @@ public struct DiscordGuildTextChannel : DiscordTextChannel, DiscordGuildChannel 
     /// The last message received on this channel.
     ///
     /// **NOTE** Currently is not being updated.
-    public var lastMessageId: String
+    public var lastMessageId: MessageID
 
     /// The name of this channel.
     public var name: String
 
     /// The permissions specifics to this channel.
-    public var permissionOverwrites: [String: DiscordPermissionOverwrite]
+    public var permissionOverwrites: [OverwriteID: DiscordPermissionOverwrite]
 
     /// The position of this channel. Mostly for UI purpose.
     public var position: Int
@@ -183,9 +183,9 @@ public struct DiscordGuildTextChannel : DiscordTextChannel, DiscordGuildChannel 
     public var topic: String
 
     init(guildChannelObject: [String: Any], client: DiscordClient? = nil) {
-        id = guildChannelObject.get("id", or: "")
-        guildId = guildChannelObject.get("guild_id", or: "")
-        lastMessageId = guildChannelObject.get("last_message_id", or: "") as String
+        id = Snowflake(guildChannelObject["id"] as? String) ?? 0
+        guildId = Snowflake(guildChannelObject["guild_id"] as? String) ?? 0
+        lastMessageId = Snowflake(guildChannelObject["last_message_id"] as? String) ?? 0
         name = guildChannelObject.get("name", or: "")
         permissionOverwrites = DiscordPermissionOverwrite.overwritesFromArray(
             guildChannelObject.get("permission_overwrites", or: JSONArray()))
@@ -199,13 +199,13 @@ public struct DiscordGuildVoiceChannel : DiscordGuildChannel {
     // MARK: Guild Voice Channel Properties
     
     /// The snowflake id of the channel.
-    public let id: String
+    public let id: ChannelID
     
     /// Whether this is a private channel. Should always be false for GuildChannels.
     public var isPrivate: Bool { return false }
     
     /// The snowflake id of the guild this channel is on.
-    public let guildId: String
+    public let guildId: GuildID
     
     /// The bitrate of this channel, if this is a voice channel.
     public var bitrate: Int
@@ -217,7 +217,7 @@ public struct DiscordGuildVoiceChannel : DiscordGuildChannel {
     public var name: String
     
     /// The permissions specifics to this channel.
-    public var permissionOverwrites: [String: DiscordPermissionOverwrite]
+    public var permissionOverwrites: [OverwriteID: DiscordPermissionOverwrite]
     
     /// The position of this channel. Mostly for UI purpose.
     public var position: Int
@@ -226,8 +226,8 @@ public struct DiscordGuildVoiceChannel : DiscordGuildChannel {
     public var userLimit: Int
     
     init(guildChannelObject: [String: Any], client: DiscordClient? = nil) {
-        id = guildChannelObject.get("id", or: "")
-        guildId = guildChannelObject.get("guild_id", or: "")
+        id = Snowflake(guildChannelObject["id"] as? String) ?? 0
+        guildId = Snowflake(guildChannelObject["guild_id"] as? String) ?? 0
         bitrate = guildChannelObject.get("bitrate", or: 0) as Int
         name = guildChannelObject.get("name", or: "")
         permissionOverwrites = DiscordPermissionOverwrite.overwritesFromArray(

--- a/Sources/SwiftDiscord/DiscordInvite.swift
+++ b/Sources/SwiftDiscord/DiscordInvite.swift
@@ -47,7 +47,7 @@ public struct DiscordInviteGuild {
     // MARK: Properties
 
     /// The snowflake id of the guild this invite is for.
-    public let id: String
+    public let id: GuildID
 
     /// The name of the guild this invite is for.
     public let name: String
@@ -56,7 +56,7 @@ public struct DiscordInviteGuild {
     public let splashHash: String
 
     init(inviteGuildObject: [String: Any]) {
-        id = inviteGuildObject.get("id", or: "")
+        id = Snowflake(inviteGuildObject["id"] as? String) ?? 0
         name = inviteGuildObject.get("name", or: "")
         splashHash = inviteGuildObject.get("splash_hash", or: "")
     }
@@ -67,7 +67,7 @@ public struct DiscordInviteChannel {
     // MARK: Properties
 
     /// The snowflake id of the channel this invite is for.
-    public let id: String
+    public let id: ChannelID
 
     /// The name of the channel this invite is for.
     public let name: String
@@ -76,7 +76,7 @@ public struct DiscordInviteChannel {
     public let type: DiscordChannelType
 
     init(inviteChannelObject: [String: Any]) {
-        id = inviteChannelObject.get("id", or: "")
+        id = Snowflake(inviteChannelObject["id"] as? String) ?? 0
         name = inviteChannelObject.get("name", or: "")
         type = DiscordChannelType(rawValue: inviteChannelObject.get("type", or: 0)) ?? .text
     }

--- a/Sources/SwiftDiscord/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/DiscordMessage.swift
@@ -39,7 +39,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     public let author: DiscordUser
 
     /// The snowflake id of the channel this message is on.
-    public let channelId: String
+    public let channelId: ChannelID
 
     /// A reference to the client.
     public weak var client: DiscordClient?
@@ -54,7 +54,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     public let embeds: [DiscordEmbed]
 
     /// The snowflake id of this message.
-    public let id: String
+    public let id: MessageID
 
     /// Whether or not this message mentioned everyone.
     public let mentionEveryone: Bool
@@ -66,7 +66,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     public let mentions: [DiscordUser]
 
     /// Used for validating a message was sent.
-    public let nonce: String
+    public let nonce: Snowflake
 
     /// Whether this message is pinned.
     public let pinned: Bool
@@ -92,14 +92,14 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     init(messageObject: [String: Any], client: DiscordClient?) {
         attachments = DiscordAttachment.attachmentsFromArray(messageObject.get("attachments", or: JSONArray()))
         author = DiscordUser(userObject: messageObject.get("author", or: [String: Any]()))
-        channelId = messageObject.get("channel_id", or: "")
+        channelId = Snowflake(messageObject["channel_id"] as? String) ?? 0
         content = messageObject.get("content", or: "")
         embeds = DiscordEmbed.embedsFromArray(messageObject.get("embeds", or: JSONArray()))
-        id = messageObject.get("id", or: "")
+        id = Snowflake(messageObject["id"] as? String) ?? 0
         mentionEveryone = messageObject.get("mention_everyone", or: false)
         mentionRoles = messageObject.get("mention_roles", or: [String]())
         mentions = DiscordUser.usersFromArray(messageObject.get("mentions", or: JSONArray()))
-        nonce = messageObject.get("nonce", or: "")
+        nonce = Snowflake(messageObject["nonce"] as? String) ?? 0
         pinned = messageObject.get("pinned", or: false)
         reactions = DiscordReaction.reactionsFromArray(messageObject.get("reactions", or: []))
         tts = messageObject.get("tts", or: false)
@@ -124,12 +124,12 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         self.tts = tts
         self.attachments = []
         self.author = DiscordUser(userObject: [:])
-        self.channelId = ""
-        self.id = ""
+        self.channelId = 0
+        self.id = 0
         self.mentionEveryone = false
         self.mentionRoles = []
         self.mentions = []
-        self.nonce = ""
+        self.nonce = 0
         self.pinned = false
         self.reactions = []
         self.editedTimestamp = Date()

--- a/Sources/SwiftDiscord/DiscordOAuth.swift
+++ b/Sources/SwiftDiscord/DiscordOAuth.swift
@@ -84,7 +84,7 @@ public enum DiscordOAuthEndpoint : String {
 
         return DiscordOAuthEndpoint.bot.createURL(getParams: [
             "permissions": permissions.rawValue.description,
-            "client_id": user.id
+            "client_id": user.id.description
         ])
     }
 }

--- a/Sources/SwiftDiscord/DiscordPermission.swift
+++ b/Sources/SwiftDiscord/DiscordPermission.swift
@@ -115,7 +115,7 @@ public struct DiscordPermissionOverwrite : JSONAble {
     // MARK: Properties
 
     /// The snowflake id of this permission overwrite.
-    public let id: String
+    public let id: OverwriteID
 
     /// The type of this overwrite.
     public let type: DiscordPermissionOverwriteType
@@ -136,7 +136,7 @@ public struct DiscordPermissionOverwrite : JSONAble {
         - parameter allow: The permissions allowed
         - parameter deny: The permissions denied
     */
-    public init(id: String, type: DiscordPermissionOverwriteType, allow: DiscordPermission, deny: DiscordPermission) {
+    public init(id: OverwriteID, type: DiscordPermissionOverwriteType, allow: DiscordPermission, deny: DiscordPermission) {
         self.id = id
         self.type = type
         self.allow = allow
@@ -144,14 +144,14 @@ public struct DiscordPermissionOverwrite : JSONAble {
     }
 
     init(permissionOverwriteObject: [String: Any]) {
-        id = permissionOverwriteObject.get("id", or: "")
+        id = Snowflake(permissionOverwriteObject["id"] as? String) ?? 0
         type = DiscordPermissionOverwriteType(rawValue: permissionOverwriteObject.get("type", or: "")) ?? .role
         allow = DiscordPermission(rawValue: permissionOverwriteObject.get("allow", or: 0))
         deny = DiscordPermission(rawValue: permissionOverwriteObject.get("deny", or: 0))
     }
 
-    static func overwritesFromArray(_ permissionOverwritesArray: [[String: Any]]) -> [String: DiscordPermissionOverwrite] {
-        var overwrites = [String: DiscordPermissionOverwrite]()
+    static func overwritesFromArray(_ permissionOverwritesArray: [[String: Any]]) -> [OverwriteID: DiscordPermissionOverwrite] {
+        var overwrites = [OverwriteID: DiscordPermissionOverwrite]()
 
         for overwriteObject in permissionOverwritesArray {
             let overwrite = DiscordPermissionOverwrite(permissionOverwriteObject: overwriteObject)

--- a/Sources/SwiftDiscord/DiscordPresence.swift
+++ b/Sources/SwiftDiscord/DiscordPresence.swift
@@ -99,7 +99,7 @@ public struct DiscordPresence {
     // MARK: Properties
 
     /// The snowflake of the guild this presence belongs on.
-    public let guildId: String
+    public let guildId: GuildID
 
     /// The user associated with this presence.
     public let user: DiscordUser
@@ -116,7 +116,7 @@ public struct DiscordPresence {
     /// The status of this user.
     public var status: DiscordPresenceStatus
 
-    init(presenceObject: [String: Any], guildId: String) {
+    init(presenceObject: [String: Any], guildId: GuildID) {
         self.guildId = guildId
         user = DiscordUser(userObject: presenceObject.get("user", or: [String: Any]()))
         game = DiscordGame(gameObject: presenceObject["game"] as? [String: Any])
@@ -145,12 +145,12 @@ public struct DiscordPresence {
         }
     }
 
-    static func presencesFromArray(_ presencesArray: [[String: Any]], guildId: String)
-            -> DiscordLazyDictionary<String, DiscordPresence> {
-        var presences = DiscordLazyDictionary<String, DiscordPresence>()
+    static func presencesFromArray(_ presencesArray: [[String: Any]], guildId: GuildID)
+            -> DiscordLazyDictionary<UserID, DiscordPresence> {
+        var presences = DiscordLazyDictionary<UserID, DiscordPresence>()
 
         for presence in presencesArray {
-            guard let user = presence["user"] as? [String: Any], let id = user["id"] as? String else {
+            guard let user = presence["user"] as? [String: Any], let id = Snowflake(user["id"] as? String) else {
                 fatalError("Couldn't extract userId")
             }
 

--- a/Sources/SwiftDiscord/DiscordRole.swift
+++ b/Sources/SwiftDiscord/DiscordRole.swift
@@ -20,7 +20,7 @@ public struct DiscordRole : JSONAble, Equatable {
     // MARK: Properties
 
     /// The snowflake id of the role.
-    public let id: String
+    public let id: RoleID
 
     /// The display color of this role.
     public var color: Int
@@ -46,7 +46,7 @@ public struct DiscordRole : JSONAble, Equatable {
     init(roleObject: [String: Any]) {
         color = roleObject.get("color", or: 0)
         hoist = roleObject.get("hoist", or: false)
-        id = roleObject.get("id", or: "")
+        id = Snowflake(roleObject["id"] as? String) ?? 0
         managed = roleObject.get("managed", or: false)
         mentionable = roleObject.get("mentionable", or: false)
         name = roleObject.get("name", or: "")
@@ -54,7 +54,7 @@ public struct DiscordRole : JSONAble, Equatable {
         position = roleObject.get("position", or: 0)
     }
 
-    init(id: String, color: Int, hoist: Bool, managed: Bool, mentionable: Bool, name: String, permissions: DiscordPermission, position: Int) {
+    init(id: RoleID, color: Int, hoist: Bool, managed: Bool, mentionable: Bool, name: String, permissions: DiscordPermission, position: Int) {
         self.id = id
         self.color = color
         self.hoist = hoist
@@ -65,8 +65,8 @@ public struct DiscordRole : JSONAble, Equatable {
         self.position = position
     }
 
-    static func rolesFromArray(_ rolesArray: [[String: Any]]) -> [String: DiscordRole] {
-        var roles = [String: DiscordRole]()
+    static func rolesFromArray(_ rolesArray: [[String: Any]]) -> [RoleID: DiscordRole] {
+        var roles = [RoleID: DiscordRole]()
 
         for role in rolesArray {
             let role = DiscordRole(roleObject: role)

--- a/Sources/SwiftDiscord/DiscordSnowflakeID.swift
+++ b/Sources/SwiftDiscord/DiscordSnowflakeID.swift
@@ -1,0 +1,128 @@
+// The MIT License (MIT)
+// Copyright (c) 2016 Erik Little
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without
+// limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+// Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+/// The stored type of a Discord Snowflake ID
+public struct Snowflake {
+
+
+    /// The internal ID storage for a snowflake
+    public let id: UInt64
+
+    /// Initialize from a UInt64
+    public init(_ snowflake: UInt64) {
+        self.id = snowflake
+    }
+
+    /// Initialize from a string
+    public init?(_ string: String) {
+        guard let snowflake = UInt64(string) else { return nil }
+        self.id = snowflake
+    }
+
+    /// Initialize from an optional string (returns nil if the input was nil or if it failed to initialize)
+    init?(_ optionalString: String?) {
+        guard let string = optionalString else { return nil }
+        guard let snowflake = Snowflake(string) else { return nil }
+        self = snowflake
+    }
+}
+
+// MARK: Snowflake Typealiases
+/// A Snowflake ID representing a Guild
+public typealias GuildID = Snowflake
+
+/// A Snowflake ID representing a Channel
+public typealias ChannelID = Snowflake
+
+/// A Snowflake ID representing a User
+public typealias UserID = Snowflake
+
+/// A Snowflake ID representing a Role
+public typealias RoleID = Snowflake
+
+/// A Snowflake ID representing a Message
+public typealias MessageID = Snowflake
+
+/// A Snowflake ID representing a Webhook
+public typealias WebhookID = Snowflake
+
+/// A Snowflake ID representing a Permissions Overwrite
+public typealias OverwriteID = Snowflake
+
+/// A Snowflake ID representing an Emoji
+public typealias EmojiID = Snowflake
+
+/// A Snowflake ID representing an Integration
+public typealias IntegrationID = Snowflake
+
+/// A Snowflake ID representing an Attachment
+public typealias AttachmentID = Snowflake
+
+// MARK: Snowflake Conformances
+
+/// Snowflake conformance to JSONRepresentable
+extension Snowflake : JSONRepresentable {
+    func jsonValue() -> JSONRepresentable {
+        // Snowflakes should be put into JSON as Strings
+        return self.description
+    }
+}
+
+/// Snowflake conformance to ExpressibleByIntegerLiteral
+extension Snowflake : ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = UInt64
+
+    /// Initialize from an integer literal
+    public init(integerLiteral value: UInt64) {
+        self.id = value
+    }
+}
+
+/// Snowflake conformance to CustomStringConvertible
+extension Snowflake : CustomStringConvertible {
+
+    /// Description for string Conversion
+    public var description: String {
+        return self.id.description
+    }
+
+}
+
+/// Snowflake conformance to Comparable
+extension Snowflake : Comparable {
+
+    /// Used to check whether two Snowflakes are equal
+    public static func ==(lhs: Snowflake, rhs: Snowflake) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    /// Used to compare Snowflakes (which is useful because a greater Snowflake was made later)
+    public static func <(lhs: Snowflake, rhs: Snowflake) -> Bool {
+        return lhs.id < rhs.id
+    }
+
+}
+
+/// Snowflake conformance to Hashable
+extension Snowflake : Hashable {
+
+    /// The hash value of the Snowflake
+    public var hashValue: Int {
+        return self.id.hashValue
+    }
+
+}

--- a/Sources/SwiftDiscord/DiscordUser.swift
+++ b/Sources/SwiftDiscord/DiscordUser.swift
@@ -32,7 +32,7 @@ public struct DiscordUser {
     public let email: String
 
     /// The snowflake id of the user.
-    public let id: String
+    public let id: UserID
 
     /// Whether this user has multi-factor authentication enabled.
     public let mfaEnabled: Bool
@@ -48,20 +48,14 @@ public struct DiscordUser {
         bot = userObject.get("bot", or: false)
         discriminator = userObject.get("discriminator", or: "")
         email = userObject.get("email", or: "")
-        id = userObject.get("id", or: "")
+        id = Snowflake(userObject["id"] as? String) ?? 0
         mfaEnabled = userObject.get("mfa_enabled", or: false)
         username = userObject.get("username", or: "")
         verified = userObject.get("verified", or: false)
     }
 
     static func usersFromArray(_ userArray: [[String: Any]]) -> [DiscordUser] {
-        var users = [DiscordUser]()
-
-        for user in userArray {
-            users.append(DiscordUser(userObject: user))
-        }
-
-        return users
+        return userArray.map(DiscordUser.init)
     }
 }
 
@@ -70,10 +64,10 @@ public protocol DiscordUserActor {
     // MARK: Properties
 
     /// The direct message channels this user is in.
-    var directChannels: [String: DiscordTextChannel] { get }
+    var directChannels: [UserID: DiscordTextChannel] { get }
 
     /// The guilds that this user is in.
-    var guilds: [String: DiscordGuild] { get }
+    var guilds: [GuildID: DiscordGuild] { get }
 
     /// The relationships this user has. Only valid for non-bot users.
     var relationships: [[String: Any]] { get }

--- a/Sources/SwiftDiscord/DiscordUserGuild.swift
+++ b/Sources/SwiftDiscord/DiscordUserGuild.swift
@@ -20,7 +20,7 @@ public struct DiscordUserGuild {
     // MARK: Properties
 
     /// The snowflake id of the guild.
-    public let id: String
+    public let id: GuildID
 
     /// The name of the guild.
     public let name: String
@@ -35,15 +35,15 @@ public struct DiscordUserGuild {
     public let permissions: DiscordPermission
 
     init(userGuildObject: [String: Any]) {
-        id = userGuildObject.get("id", or: "")
+        id = Snowflake(userGuildObject["id"] as? String) ?? 0
         name = userGuildObject.get("name", or: "")
         icon = userGuildObject.get("icon", or: "")
         owner = userGuildObject.get("owner", or: false)
         permissions = DiscordPermission(rawValue: userGuildObject.get("permissions", or: 0))
     }
 
-    static func userGuildsFromArray(_ guilds: [[String: Any]]) -> [String: DiscordUserGuild] {
-        var userGuildDictionary = [String: DiscordUserGuild]()
+    static func userGuildsFromArray(_ guilds: [[String: Any]]) -> [GuildID: DiscordUserGuild] {
+        var userGuildDictionary = [GuildID: DiscordUserGuild]()
 
         for guildObject in guilds {
             let guild = DiscordUserGuild(userGuildObject: guildObject)

--- a/Sources/SwiftDiscord/DiscordVoiceEngine.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceEngine.swift
@@ -60,7 +60,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
     }
 
     /// The id of the guild this voice engine is for.
-    public var guildId: String {
+    public var guildId: GuildID {
         return voiceState.guildId
     }
 

--- a/Sources/SwiftDiscord/DiscordVoiceManager.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceManager.swift
@@ -72,14 +72,14 @@ open class DiscordVoiceManager : DiscordVoiceEngineDelegate, Lockable {
     }
 
     /// The voice engines, indexed by guild id.
-    public private(set) var voiceEngines = [String: DiscordVoiceEngine]()
+    public private(set) var voiceEngines = [GuildID: DiscordVoiceEngine]()
 
     /// The voice states for this user, if they are in any voice channels.
-    public internal(set) var voiceStates = [String: DiscordVoiceState]()
+    public internal(set) var voiceStates = [GuildID: DiscordVoiceState]()
 
     let lock = DispatchSemaphore(value: 1)
 
-    var voiceServerInformations = [String: DiscordVoiceServerInformation]()
+    var voiceServerInformations = [GuildID: DiscordVoiceServerInformation]()
 
     private var logType: String { return "DiscordVoiceManager" }
 
@@ -99,7 +99,7 @@ open class DiscordVoiceManager : DiscordVoiceEngineDelegate, Lockable {
 
         - parameter onGuild: The snowflake of the guild that you want to leave.
     */
-    open func leaveVoiceChannel(onGuild guildId: String) {
+    open func leaveVoiceChannel(onGuild guildId: GuildID) {
         guard let engine = get(voiceEngines[guildId]) else { return }
 
         protected {
@@ -122,7 +122,7 @@ open class DiscordVoiceManager : DiscordVoiceEngineDelegate, Lockable {
 
         - parameter guildId: The id of the guild to connect to.
     */
-    open func startVoiceConnection(_ guildId: String) {
+    open func startVoiceConnection(_ guildId: GuildID) {
         protected {
             _startVoiceConnection(guildId)
         }
@@ -130,7 +130,7 @@ open class DiscordVoiceManager : DiscordVoiceEngineDelegate, Lockable {
 
     /// Tries to create a voice engine for a guild, and connect.
     /// **Not thread safe.**
-    private func _startVoiceConnection(_ guildId: String) {
+    private func _startVoiceConnection(_ guildId: GuildID) {
         // We need both to start the connection
         guard let voiceState = voiceStates[guildId], let serverInfo = voiceServerInformations[guildId] else {
             return

--- a/Sources/SwiftDiscord/DiscordVoiceServer.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceServer.swift
@@ -23,14 +23,14 @@ public struct DiscordVoiceServerInformation {
     public let endpoint: String
 
     /// The guild id that is associated with this update.
-    public let guildId: String
+    public let guildId: GuildID
 
     /// The token for the voice connection.
     public let token: String
 
     init(voiceServerInformationObject: [String: Any]) {
         endpoint = voiceServerInformationObject.get("endpoint", or: "")
-        guildId = voiceServerInformationObject.get("guild_id", or: "")
+        guildId = Snowflake(voiceServerInformationObject["guild_id"] as? String) ?? 0
         token = voiceServerInformationObject.get("token", or: "")
     }
 }

--- a/Sources/SwiftDiscord/DiscordVoiceState.swift
+++ b/Sources/SwiftDiscord/DiscordVoiceState.swift
@@ -20,13 +20,13 @@ public struct DiscordVoiceState {
     // MARK: Properties
 
     /// The snowflake id of the voice channel this state belongs to.
-    public let channelId: String
+    public let channelId: ChannelID
 
     /// Whether this user is deafened.
     public let deaf: Bool
 
     /// The snowflake id of the guild this state belongs to.
-    public let guildId: String
+    public let guildId: GuildID
 
     /// Whether this user is muted.
     public let mute: Bool
@@ -44,13 +44,13 @@ public struct DiscordVoiceState {
     public let suppress: Bool
 
     /// The snowflake id of the user this state is for.
-    public let userId: String
+    public let userId: UserID
 
-    init(voiceStateObject: [String: Any], guildId: String) {
+    init(voiceStateObject: [String: Any], guildId: GuildID) {
         self.guildId = guildId
-        channelId = voiceStateObject.get("channel_id", or: "")
+        channelId = Snowflake(voiceStateObject["channel_id"] as? String) ?? 0
         sessionId = voiceStateObject.get("session_id", or: "")
-        userId = voiceStateObject.get("user_id", or: "")
+        userId = Snowflake(voiceStateObject["user_id"] as? String) ?? 0
         deaf = voiceStateObject.get("deaf", or: false)
         mute = voiceStateObject.get("mute", or: false)
         selfDeaf = voiceStateObject.get("self_deaf", or: false)
@@ -58,8 +58,8 @@ public struct DiscordVoiceState {
         suppress = voiceStateObject.get("suppress", or: false)
     }
 
-    static func voiceStatesFromArray(_ voiceStateArray: [[String: Any]], guildId: String) -> [String: DiscordVoiceState] {
-        var voiceStates = [String: DiscordVoiceState]()
+    static func voiceStatesFromArray(_ voiceStateArray: [[String: Any]], guildId: GuildID) -> [UserID: DiscordVoiceState] {
+        var voiceStates = [UserID: DiscordVoiceState]()
 
         for voiceState in voiceStateArray {
             let voiceState = DiscordVoiceState(voiceStateObject: voiceState, guildId: guildId)

--- a/Sources/SwiftDiscord/DiscordWebhook.swift
+++ b/Sources/SwiftDiscord/DiscordWebhook.swift
@@ -25,13 +25,13 @@ public struct DiscordWebhook {
     public let avatar: String?
 
     /// The snowflake for the channel this webhook is for.
-    public let channelId: String
+    public let channelId: ChannelID
 
     /// The snowflake for of the guild this webhook is for, if for a guild.
-    public let guildId: String?
+    public let guildId: GuildID?
 
     /// The id of this webhook.
-    public let id: String
+    public let id: WebhookID
 
     /// The default name of this webhook.
     public let name: String?
@@ -44,9 +44,9 @@ public struct DiscordWebhook {
 
     init(webhookObject: [String: Any]) {
         avatar = webhookObject["avatar"] as? String
-        channelId = webhookObject.get("channel_id", or: "")
-        guildId = webhookObject["guild_id"] as? String
-        id = webhookObject.get("id", or: "")
+        channelId = Snowflake(webhookObject["channel_id"] as? String) ?? 0
+        guildId = Snowflake(webhookObject["guild_id"] as? String)
+        id = Snowflake(webhookObject["id"] as? String) ?? 0
         name = webhookObject["name"] as? String
         token = webhookObject.get("token", or: "")
 

--- a/Tests/SwiftDiscordTests/Fixtures.swift
+++ b/Tests/SwiftDiscordTests/Fixtures.swift
@@ -4,13 +4,15 @@
 
 import Foundation
 
+// IDs: Guild: 1xx, Channel: 2xx, User: 3xx, Role: 4xx, Emoji: 5xx, Message: 6xx
+
 let helloPacket = "{\"t\":null,\"s\":null,\"op\":10,\"d\":{\"heartbeat_interval\":41250,\"_trace\":[\"discord-gateway-prd-1-24\"]}}"
 let readyPacket = "{\"t\":\"READY\",\"s\":null,\"op\":0,\"d\":{\"session_id\": \"hello_world\"}}"
 
 let testRole: [String: Any] = [
     "color": 0,
     "hoist": false,
-    "id": "testRole",
+    "id": "400",
     "managed": false,
     "mentionable": true,
     "name": "My Test Role",
@@ -21,7 +23,7 @@ let testRole: [String: Any] = [
 let testEmoji: [String: Any] = [
     "id": "testEmoji",
     "managed": false,
-    "name": "test_emoji",
+    "name": "500",
     "require_colons": true,
     "roles": [] as [String]
 ]
@@ -31,7 +33,7 @@ let testUser: [String: Any] = [
     "bot": false,
     "discriminator": "",
     "email": "",
-    "id": "testuser",
+    "id": "300",
     "mfa_enabled": false,
     "username": "TestUser",
     "verified": true
@@ -42,7 +44,7 @@ let testMember: [String: Any] = [
     "deaf": false,
     "mute": false,
     "nick": "",
-    "roles": ["testRole"],
+    "roles": ["400"],
     "joined_at": ""
 ]
 
@@ -53,7 +55,7 @@ let testGame: [String: Any] = [
 ]
 
 let testPresence: [String: Any] = [
-    "guild_id": "testGuild",
+    "guild_id": "100",
     "user": testUser,
     "game": testGame,
     "nick": "",
@@ -61,8 +63,8 @@ let testPresence: [String: Any] = [
 ]
 
 let testGuildTextChannel: [String: Any] = [
-    "id": "guildTextChannel",
-    "guild_id": "testGuild",
+    "id": "200",
+    "guild_id": "100",
     "type": 0,
     "name": "TestTextChannel",
     "permission_overwrites": [[String: Any]](),
@@ -70,7 +72,7 @@ let testGuildTextChannel: [String: Any] = [
 ]
 
 let testGuildVoiceChannel: [String: Any] = [
-    "id": "guildVoiceChannel",
+    "id": "202",
     "guild_id": "testGuild",
     "type": 2,
     "name": "TestVoiceChannel",
@@ -89,7 +91,7 @@ let testGuild: [String: Any] = [
     "emojis": [[String: Any]](),
     "features": [Any](),
     "icon": "",
-    "id": "testGuild",
+    "id": "100",
     "large": false,
     "member_count": 0,
     "mfa_level": 0,
@@ -130,7 +132,7 @@ let testMessage: [String: Any] = [
     "channel_id": testGuildTextChannel["id"] as! String,
     "content": "This is a test message",
     "embeds": [testEmbed],
-    "id": "testMessage",
+    "id": "600",
     "mention_everyone": false,
     "mention_roles": [String](),
     "mentions": [[String: Any]](),
@@ -180,7 +182,7 @@ func createEmojiObjects(n: Int) -> [[String: Any]] {
     for i in 0..<n {
         var emoji = testUser
 
-        emoji["id"] = String("emoji\(i)")
+        emoji["id"] = String("500\(i)")
         emoji["name"] = String("Custom emoji \(i)")
 
         emojis.append(emoji)

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -1,0 +1,48 @@
+//
+//  Created by TellowKrinkle on 2017/06/26.
+//
+
+import XCTest
+@testable import SwiftDiscord
+
+class TestDiscordDataStructures : XCTestCase {
+    func testRoleJSONification() {
+        let role1 = DiscordRole(id: 324, color: 43, hoist: false, managed: true, mentionable: false, name: "Test Role", permissions: [.addReactions], position: 4)
+        let role2 = DiscordRole(roleObject: role1.json)
+
+        XCTAssertEqual(role1.id, role2.id, "Role ID should survive JSONification")
+        XCTAssertEqual(role1.color, role2.color, "Color should survive JSONification")
+        XCTAssertEqual(role1.hoist, role2.hoist, "Hoist should survive JSONification")
+        XCTAssertEqual(role1.managed, role2.managed, "Managed should survive JSONification")
+        XCTAssertEqual(role1.mentionable, role2.mentionable, "Mentionable should survive JSONification")
+        XCTAssertEqual(role1.name, role2.name, "Name should survive JSONificaiton")
+        XCTAssertEqual(role1.permissions, role2.permissions, "Permissions should survive JSONification")
+        XCTAssertEqual(role1.position, role2.position, "Position should survive JSONification")
+    }
+
+    func testPermissionOverwriteJSONification() {
+        let overwrite1 = DiscordPermissionOverwrite(id: 5234, type: .member, allow: [.changeNickname, .voice], deny: [.manageChannels])
+        let overwrite2 = DiscordPermissionOverwrite(permissionOverwriteObject: overwrite1.json)
+
+        XCTAssertEqual(overwrite1.id, overwrite2.id, "Permission Overwrite ID should survive JSONification")
+        XCTAssertEqual(overwrite1.type, overwrite2.type, "Type should survive JSONification")
+        XCTAssertEqual(overwrite1.allow, overwrite2.allow, "Allow should survive JSONification")
+        XCTAssertEqual(overwrite1.deny, overwrite2.deny, "Deny should survive JSONification")
+        let overwrite3 = DiscordPermissionOverwrite(id: 934, type: .role, allow: [], deny: [])
+        let overwrite4 = DiscordPermissionOverwrite(permissionOverwriteObject: overwrite3.json)
+        XCTAssertEqual(overwrite3.type, overwrite4.type, "Type should survive JSONification")
+    }
+
+    func testGameJSONification() {
+        let game1 = DiscordGame(name: "Game", type: .game)
+        let game2 = DiscordGame(gameObject: game1.json)!
+        let game3 = DiscordGame(name: "Another Game", type: .stream, url: "http://www.twitch.tv/person")
+        let game4 = DiscordGame(gameObject: game3.json)!
+        XCTAssertEqual(game1.name, game2.name, "Name should survive JSONification")
+        XCTAssertEqual(game1.type, game2.type, "Type should survive JSONification")
+        XCTAssertEqual(game1.url, game2.url, "Nil URL should survive JSONification")
+        XCTAssertEqual(game3.name, game4.name, "Name should survive JSONification")
+        XCTAssertEqual(game3.type, game4.type, "Type should survive JSONification")
+        XCTAssertEqual(game3.url, game4.url, "URL should survive JSONification")
+    }
+}

--- a/Tests/SwiftDiscordTests/TestDiscordGuild.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordGuild.swift
@@ -10,7 +10,7 @@ class TestDiscordGuild : XCTestCase {
     func testCreatingGuildSetsId() {
         let guild = DiscordGuild(guildObject: testGuild, client: nil)
 
-        XCTAssertEqual(guild.id, "testGuild", "init should set id")
+        XCTAssertEqual(guild.id, 100, "init should set id")
     }
 
     func testCreatingGuildSetsName() {
@@ -34,11 +34,11 @@ class TestDiscordGuild : XCTestCase {
     }
 
     func testCreatingGuildSetsEmbedChannel() {
-        tGuild["embed_channel_id"] = "testChannel"
+        tGuild["embed_channel_id"] = "200"
 
         let guild = DiscordGuild(guildObject: tGuild, client: nil)
 
-        XCTAssertEqual(guild.embedChannelId, "testChannel", "init should set the embed channel id")
+        XCTAssertEqual(guild.embedChannelId, 200, "init should set the embed channel id")
     }
 
     func testCreatingGuildSetsIcon() {
@@ -74,11 +74,11 @@ class TestDiscordGuild : XCTestCase {
     }
 
     func testCreatingGuildSetsOwnerId() {
-        tGuild["owner_id"] = "someowner"
+        tGuild["owner_id"] = "601"
 
         let guild = DiscordGuild(guildObject: tGuild, client: nil)
 
-        XCTAssertEqual(guild.ownerId, "someowner", "init should set owner id")
+        XCTAssertEqual(guild.ownerId, 601, "init should set owner id")
     }
 
     func testCreatingGuildSetsRegion() {
@@ -117,7 +117,7 @@ class TestDiscordGuild : XCTestCase {
         var tMember = testMember
         var role2 = testRole
 
-        role2["id"] = "testRole2"
+        role2["id"] = "401"
         role2["name"] = "A new role"
         tMember["roles"] = [testRole["id"] as! String, role2["id"] as! String]
 
@@ -131,8 +131,8 @@ class TestDiscordGuild : XCTestCase {
         let roles = guild.roles(for: member)
 
         XCTAssertEqual(roles.count, 2, "guild should find two roles for member")
-        XCTAssertNotNil(roles.first(where: { $0.id == testRole["id"] as! String }), "roles should find testrole")
-        XCTAssertNotNil(roles.first(where: { $0.id == role2["id"] as! String }), "roles should find role2")
+        XCTAssertNotNil(roles.first(where: { $0.id == Snowflake(testRole["id"] as! String)! }), "roles should find testrole")
+        XCTAssertNotNil(roles.first(where: { $0.id == Snowflake(role2["id"] as! String)! }), "roles should find role2")
     }
 
     func testCreatingGuildWithALargeNumberOfMembersIsFast() {
@@ -145,7 +145,7 @@ class TestDiscordGuild : XCTestCase {
         }
 
         XCTAssertEqual(guild.members.count, 100_000, "init should create 100_000 members")
-        XCTAssertEqual(guild.members["5000"]?.user.id, "5000", "init should create members correctly")
+        XCTAssertEqual(guild.members[5000]?.user.id, 5000, "init should create members correctly")
     }
 
     func testCreatingGuildWithALargeNumberOfPresencesIsFast() {
@@ -158,7 +158,7 @@ class TestDiscordGuild : XCTestCase {
         }
 
         XCTAssertEqual(guild.presences.count, 100_000, "init should create 100_000 presences")
-        XCTAssertEqual(guild.presences["5000"]?.user.id, "5000", "init should create presences correctly")
+        XCTAssertEqual(guild.presences[5000]?.user.id, 5000, "init should create presences correctly")
     }
 
     var tGuild: [String: Any]!

--- a/Tests/SwiftDiscordTests/TestDiscordGuildMember.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordGuildMember.swift
@@ -33,7 +33,7 @@ class TestDiscordGuildMember : XCTestCase {
         var member = DiscordGuildMember(guildMemberObject: testMember, guildId: guild.id, guild: guild)
 
         _ = member.updateMember(["nick": "A new nick",
-                                 "roles": ["testRole", "testRole2"]
+                                 "roles": ["400", "401"]
                                 ])
 
         XCTAssertEqual(member.nick, "A new nick", "Member should have a new nick")

--- a/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
@@ -14,10 +14,10 @@ let permissionsTestUsers = ["23416345", "32564235", "4359835345", "32499342123",
 
 let permissionsTestUserPermissions: DiscordPermission = [.createInstantInvite, .addReactions, .readMessages, .sendMessages, .readMessageHistory, .useExternalEmojis, .connect, .speak, .useVAD, .changeNickname]
 let permissionsTestRoles: [DiscordRole] = [
-    DiscordRole(id: "2349683489545", color: 10181046, hoist: true, managed: false, mentionable: true, name: "Admin", permissions: .administrator, position: 3),
-    DiscordRole(id: "32423425264343", color: 10718666, hoist: true, managed: false, mentionable: true, name: "Mod", permissions: permissionsTestUserPermissions.union([.kickMembers, .manageChannels, .viewAuditLog, .sendTTSMessages, .embedLinks, .attachFiles, .mentionEveryone, .muteMembers, .deafenMembers, .moveMembers, .manageNicknames, .manageRoles]), position: 2),
-    DiscordRole(id: "34634634534564", color: 567526, hoist: true, managed: false, mentionable: true, name: "Test", permissions: permissionsTestUserPermissions, position: 1),
-    DiscordRole(id: "34029736498534", color: 0, hoist: false, managed: false, mentionable: false, name: "Muted", permissions: permissionsTestUserPermissions, position: 0)
+    DiscordRole(id: 2349683489545, color: 10181046, hoist: true, managed: false, mentionable: true, name: "Admin", permissions: .administrator, position: 3),
+    DiscordRole(id: 32423425264343, color: 10718666, hoist: true, managed: false, mentionable: true, name: "Mod", permissions: permissionsTestUserPermissions.union([.kickMembers, .manageChannels, .viewAuditLog, .sendTTSMessages, .embedLinks, .attachFiles, .mentionEveryone, .muteMembers, .deafenMembers, .moveMembers, .manageNicknames, .manageRoles]), position: 2),
+    DiscordRole(id: 34634634534564, color: 567526, hoist: true, managed: false, mentionable: true, name: "Test", permissions: permissionsTestUserPermissions, position: 1),
+    DiscordRole(id: 34029736498534, color: 0, hoist: false, managed: false, mentionable: false, name: "Muted", permissions: permissionsTestUserPermissions, position: 0)
 ]
 
 class PermissionsTestClientDelegate: DiscordClientDelegate { }
@@ -26,14 +26,14 @@ let permissionsTestClient = DiscordClient(token: "Testing", delegate: permission
 
 let permissionsTestGuildJSON = { () -> [String: Any] in
     var tmp = testGuild
-    tmp["owner_id"] = permissionsTestUsers[0].id
+	tmp["owner_id"] = String(describing: permissionsTestUsers[0].id)
     tmp["roles"] = try! permissionsTestRoles.jsonValue()
     return tmp
 }()
 
 let permissionsTestGuild = DiscordGuild(guildObject: permissionsTestGuildJSON, client: permissionsTestClient)
 
-let permissionTestMemberRoles: [[String]] = [
+let permissionTestMemberRoles: [[RoleID]] = [
     [permissionsTestRoles[3].id],
     [permissionsTestRoles[0].id, permissionsTestRoles[2].id],
     [permissionsTestRoles[1].id],
@@ -48,9 +48,9 @@ let permissionsTestMembers = zip(permissionsTestUsers, permissionTestMemberRoles
 func createPermissionTestChannel(overwrites: [DiscordPermissionOverwrite]) -> DiscordGuildTextChannel {
     var channelData = testGuildTextChannel
     channelData["permission_overwrites"] = try? overwrites.jsonValue()
-    channelData["guild_id"] = permissionsTestGuild.id
+	channelData["guild_id"] = String(describing: permissionsTestGuild.id)
     permissionsTestClient.handleChannelCreate(with: channelData)
-    return permissionsTestClient.findChannel(fromId: channelData["id"] as! String) as! DiscordGuildTextChannel
+    return permissionsTestClient.findChannel(fromId: Snowflake(channelData["id"] as! String)!) as! DiscordGuildTextChannel
 }
 
 class TestDiscordPermissions : XCTestCase {


### PR DESCRIPTION
This PR converts the storage of Snowflake IDs from Strings to UInt64s.

Benefits:
- About 10x less memory used per unique Snowflake (Hopefully copied Strings share storage, so they'd use less, probably around 2 UInt64s)
- Faster dictionary accesses with Snowflake IDs

Drawbacks:
- Slightly slower processing of IDs from JSON (though this gets offset if the struct is inserted into a dictionary afterwards)
- No more non-number IDs in tests

This PR also adds some type aliases to Snowflake to make Xcode's code completion more understandable.  For example, the completion for add guild member role looks like
client.addGuildMemberRole(`roleId: RoleID`, to: `UserID`, on: `GuildID`, callback: `((Bool) -> ())?`) instead of
client.addGuildMemberRole(`roleId: String`, to: `String`, on: `String`, callback: `((Bool) -> ())?`).

Finally, this PR adds a few new tests around JSONification of structs.  It only adds easy ones, where the struct both conformed to `JSONAble` and had an `init(json)` method.