### PR TITLE
Fix an issue where guild channels always had the guild ID 0

### DIFF
--- a/Sources/SwiftDiscord/Channel/DiscordChannel.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordChannel.swift
@@ -185,8 +185,8 @@ func channelFromObject(_ object: [String: Any], withClient client: DiscordClient
     guard let type = DiscordChannelType(rawValue: object.get("type", or: -1)) else { return nil }
 
     switch type {
-    case .text:     return DiscordGuildTextChannel(guildChannelObject: object, client: client)
-    case .voice:    return DiscordGuildVoiceChannel(guildChannelObject: object, client: client)
+    case .text:     return DiscordGuildTextChannel(guildChannelObject: object, guildID: nil, client: client)
+    case .voice:    return DiscordGuildVoiceChannel(guildChannelObject: object, guildID: nil, client: client)
     case .direct:   return DiscordDMChannel(dmReadyObject: object, client: client)
     case .groupDM:  return DiscordGroupDMChannel(dmReadyObject: object, client: client)
     }

--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -502,7 +502,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func handleChannelUpdate(with data: [String: Any]) {
         DefaultDiscordLogger.Logger.log("Handling channel update", type: logType)
 
-        let channel = guildChannelFromObject(data, client: self)
+        let channel = guildChannelFromObject(data, guildID: nil, client: self)
 
         DefaultDiscordLogger.Logger.verbose("Updated channel: \(channel)", type: logType)
 

--- a/Sources/SwiftDiscord/Guild/DiscordGuild.swift
+++ b/Sources/SwiftDiscord/Guild/DiscordGuild.swift
@@ -103,14 +103,14 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
     public private(set) var verificationLevel: Int
 
     init(guildObject: [String: Any], client: DiscordClient?) {
-        channels = guildChannelsFromArray(guildObject.get("channels", or: JSONArray()), client: client)
+        id = Snowflake(guildObject["id"] as? String) ?? 0
+        channels = guildChannelsFromArray(guildObject.get("channels", or: JSONArray()), guildID: id, client: client)
         defaultMessageNotifications = guildObject.get("default_message_notifications", or: -1)
         embedEnabled = guildObject.get("embed_enabled", or: false)
         embedChannelId = Snowflake(guildObject["embed_channel_id"] as? String) ?? 0
         emojis = DiscordEmoji.emojisFromArray(guildObject.get("emojis", or: JSONArray()))
         features = guildObject.get("features", or: Array<Any>())
         icon = guildObject.get("icon", or: "")
-        id = Snowflake(guildObject["id"] as? String) ?? 0
         large = guildObject.get("large", or: false)
         memberCount = guildObject.get("member_count", or: 0)
         mfaLevel = guildObject.get("mfa_level", or: -1)

--- a/Sources/SwiftDiscord/Guild/DiscordGuildChannel.swift
+++ b/Sources/SwiftDiscord/Guild/DiscordGuildChannel.swift
@@ -129,20 +129,21 @@ extension DiscordGuildChannel {
     }
 }
 
-func guildChannelFromObject(_ channelObject: [String: Any], client: DiscordClient? = nil) -> DiscordGuildChannel {
+func guildChannelFromObject(_ channelObject: [String: Any], guildID: GuildID?, client: DiscordClient? = nil) -> DiscordGuildChannel {
     if channelObject["type"] as? Int == DiscordChannelType.voice.rawValue {
-        return DiscordGuildVoiceChannel(guildChannelObject: channelObject, client: client)
+        return DiscordGuildVoiceChannel(guildChannelObject: channelObject, guildID: guildID, client: client)
     } else {
-        return DiscordGuildTextChannel(guildChannelObject: channelObject, client: client)
+        return DiscordGuildTextChannel(guildChannelObject: channelObject, guildID: guildID, client: client)
     }
 }
 
 func guildChannelsFromArray(_ guildChannelArray: [[String: Any]],
+                            guildID: GuildID?,
                             client: DiscordClient? = nil) -> [ChannelID: DiscordGuildChannel] {
         var guildChannels = [ChannelID: DiscordGuildChannel]()
 
         for guildChannelObject in guildChannelArray {
-            let guildChannel = guildChannelFromObject(guildChannelObject, client: client)
+            let guildChannel = guildChannelFromObject(guildChannelObject, guildID: guildID, client: client)
             guildChannels[guildChannel.id] = guildChannel
         }
 
@@ -179,9 +180,9 @@ public struct DiscordGuildTextChannel : DiscordTextChannel, DiscordGuildChannel 
     /// The topic of this channel, if this is a text channel.
     public var topic: String
 
-    init(guildChannelObject: [String: Any], client: DiscordClient? = nil) {
+    init(guildChannelObject: [String: Any], guildID: GuildID?, client: DiscordClient? = nil) {
         id = Snowflake(guildChannelObject["id"] as? String) ?? 0
-        guildId = Snowflake(guildChannelObject["guild_id"] as? String) ?? 0
+        guildId = guildID ?? Snowflake(guildChannelObject["guild_id"] as? String) ?? 0
         lastMessageId = Snowflake(guildChannelObject["last_message_id"] as? String) ?? 0
         name = guildChannelObject.get("name", or: "")
         permissionOverwrites = DiscordPermissionOverwrite.overwritesFromArray(
@@ -220,9 +221,9 @@ public struct DiscordGuildVoiceChannel : DiscordGuildChannel {
     /// The user limit of this channel, if this is a voice channel.
     public var userLimit: Int
 
-    init(guildChannelObject: [String: Any], client: DiscordClient? = nil) {
+    init(guildChannelObject: [String: Any], guildID: GuildID?, client: DiscordClient? = nil) {
         id = Snowflake(guildChannelObject["id"] as? String) ?? 0
-        guildId = Snowflake(guildChannelObject["guild_id"] as? String) ?? 0
+        guildId = guildID ?? Snowflake(guildChannelObject["guild_id"] as? String) ?? 0
         bitrate = guildChannelObject.get("bitrate", or: 0) as Int
         name = guildChannelObject.get("name", or: "")
         permissionOverwrites = DiscordPermissionOverwrite.overwritesFromArray(

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -247,7 +247,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback?(guildChannelFromObject(channel))
+            callback?(guildChannelFromObject(channel, guildID: nil))
         }
 
         rateLimiter.executeRequest(endpoint: .channel(id: channelId),

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Guilds.swift
@@ -56,7 +56,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback?(guildChannelFromObject(channel))
+            callback?(guildChannelFromObject(channel, guildID: guildId))
         }
 
         rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
@@ -152,7 +152,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback(guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
+            callback(guildChannelsFromArray(channels as! [[String: Any]], guildID: guildId).map({ $0.value }))
         }
 
         rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),
@@ -298,7 +298,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                 return
             }
 
-            callback?(guildChannelsFromArray(channels as! [[String: Any]]).map({ $0.value }))
+            callback?(Array(guildChannelsFromArray(channels as! [[String: Any]], guildID: guildId).values))
         }
 
         rateLimiter.executeRequest(endpoint: .guildChannels(guild: guildId),


### PR DESCRIPTION
Discord doesn't actually send back the Guild ID in the response for the guildChannels endpoint.