### PR TITLE
Easier embeds

### DIFF
--- a/Sources/SwiftDiscord/Audit/DiscordAuditLogEntry.swift
+++ b/Sources/SwiftDiscord/Audit/DiscordAuditLogEntry.swift
@@ -113,7 +113,7 @@ public enum DiscordAuditLogActionType : Int {
     case memberPrune = 21
 
     /// Member ban add.
-    case memberBanAdd =	22
+    case memberBanAdd = 22
 
     /// Member ban remove.
     case memberBanRemove = 23

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -248,19 +248,20 @@ public struct DiscordEmbed : JSONAble {
 
     /// Represents an Embed's author.
     public struct Author : JSONAble {
+        var shouldIncludeNilsInJSON: Bool { return false }
         // MARK: Properties
 
         /// The name for this author.
-        public let name: String?
+        public var name: String
 
         /// The icon for this url.
-        public let iconUrl: URL?
+        public var iconUrl: URL?
 
         /// The proxy url for the icon.
-        public let proxyUrl: URL?
+        public let proxyIconUrl: URL?
 
         /// The url of this author.
-        public let url: URL?
+        public var url: URL?
 
         /**
             Creates an Author object.
@@ -269,11 +270,19 @@ public struct DiscordEmbed : JSONAble {
             - parameter iconUrl: The iconUrl for this author's icon.
             - parameter url: The url for this author.
         */
-        public init(name: String?, iconUrl: URL?, url: URL?) {
+        public init(name: String, iconUrl: URL? = nil, url: URL? = nil) {
             self.name = name
             self.iconUrl = iconUrl
             self.url = url
-            self.proxyUrl = nil
+            self.proxyIconUrl = nil
+        }
+
+        /// For testing
+        internal init(name: String, iconURL: URL?, url: URL?, proxyURL: URL?) {
+            self.name = name
+            self.iconUrl = iconURL
+            self.url = url
+            self.proxyIconUrl = proxyURL
         }
     }
 
@@ -282,13 +291,13 @@ public struct DiscordEmbed : JSONAble {
         // MARK: Properties
 
         /// The name of the field.
-        public let name: String
+        public var name: String
 
         /// The value of the field.
-        public let value: String
+        public var value: String
 
         /// Whether this field should be inlined
-        public let inline: Bool
+        public var inline: Bool
 
         // MARK: Initializers
 
@@ -299,7 +308,7 @@ public struct DiscordEmbed : JSONAble {
             - parameter value: The value of this field.
             - parameter inline: Whether this field can be inlined.
         */
-        public init(name: String, value: String, inline: Bool) {
+        public init(name: String, value: String, inline: Bool = false) {
             self.name = name
             self.value = value
             self.inline = inline
@@ -308,16 +317,17 @@ public struct DiscordEmbed : JSONAble {
 
     /// Represents an Embed's footer.
     public struct Footer : JSONAble {
+        var shouldIncludeNilsInJSON: Bool { return false }
         // MARK: Properties
 
         /// The text for this footer.
-        public let text: String?
+        public var text: String?
 
         /// The icon for this url.
-        public let iconUrl: URL?
+        public var iconUrl: URL?
 
         /// The proxy url for the icon.
-        public let proxyUrl: URL?
+        public let proxyIconUrl: URL?
 
         /**
             Creates a Footer object.
@@ -328,7 +338,14 @@ public struct DiscordEmbed : JSONAble {
         public init(text: String?, iconUrl: URL?) {
             self.text = text
             self.iconUrl = iconUrl
-            self.proxyUrl = nil
+            self.proxyIconUrl = nil
+        }
+
+        /// For testing
+        internal init(text: String?, iconURL: URL?, proxyURL: URL?) {
+            self.text = text
+            self.iconUrl = iconURL
+            self.proxyIconUrl = proxyURL
         }
     }
 
@@ -339,8 +356,8 @@ public struct DiscordEmbed : JSONAble {
         /// The height of this image.
         public let height: Int
 
-        /// The text for this footer.
-        public let url: String
+        /// The url of this image.
+        public var url: URL
 
         /// The width of this image.
         public let width: Int
@@ -350,15 +367,23 @@ public struct DiscordEmbed : JSONAble {
 
             - parameter url: The url for this field.
         */
-        public init(url: String) {
+        public init(url: URL) {
             self.height = -1
             self.url = url
             self.width = -1
+        }
+
+        /// For Testing
+        internal init(url: URL, width: Int, height: Int) {
+            self.url = url
+            self.width = width
+            self.height = height
         }
     }
 
     /// Represents what is providing the content of an embed.
     public struct Provider : JSONAble {
+        var shouldIncludeNilsInJSON: Bool { return false }
         // MARK: Properties
 
         /// The name of this provider.
@@ -370,62 +395,81 @@ public struct DiscordEmbed : JSONAble {
 
     /// Represents the thumbnail of an embed.
     public struct Thumbnail : JSONAble {
+        var shouldIncludeNilsInJSON: Bool { return false }
         // MARK: Properties
 
         /// The height of this image.
         public let height: Int
 
         /// The proxy url for this image.
-        public let proxyUrl: URL
+        public let proxyUrl: URL?
 
         /// The url for this image.
-        public let url: URL
+        public var url: URL
 
         /// The width of this image.
         public let width: Int
+
+        /**
+            Creates a Thumbnail object.
+
+        - parameter url: The url for this field
+        */
+        public init(url: URL) {
+            self.url = url
+            self.height = -1
+            self.width = -1
+            self.proxyUrl = nil
+        }
+
+        /// For testing
+        internal init(url: URL, width: Int, height: Int, proxyURL: URL?) {
+            self.url = url
+            self.width = width
+            self.height = height
+            self.proxyUrl = proxyURL
+        }
     }
 
     // MARK: Properties
 
     /// The author of this embed.
-    public let author: Author?
+    public var author: Author?
 
     /// The color of this embed.
-    public let color: Int?
+    public var color: Int?
 
     /// The description of this embed.
-    public let description: String
+    public var description: String?
 
     /// The footer for this embed.
-    public let footer: Footer?
+    public var footer: Footer?
 
     /// The image for this embed.
-    public let image: Image?
+    public var image: Image?
 
     /// The provider of this embed.
     public let provider: Provider?
 
     /// The thumbnail of this embed.
-    public let thumbnail: Thumbnail?
+    public var thumbnail: Thumbnail?
 
     /// The title of this embed.
-    public let title: String
+    public var title: String?
 
     /// The type of this embed.
     public let type: String
 
     /// The url of this embed.
-    public let url: URL?
+    public var url: URL?
 
     /// The embed's fields
-    public var fields = [Field]()
+    public var fields: [Field]
 
     // MARK: Initializers
 
     /**
         Creates an Embed object.
-
-        `Field`s can be added after intialization.
 
         - parameter title: The title of this embed.
         - parameter description: The description of this embed.
@@ -435,9 +479,10 @@ public struct DiscordEmbed : JSONAble {
         - parameter thumbnail: The thumbnail of this embed, if there is one.
         - parameter color: The color of this embed.
         - parameter footer: The footer for this embed, if there is one.
+        - parameter fields: The list of fields for this embed, if there are any.
     */
-    public init(title: String,
-                description: String,
+    public init(title: String? = nil,
+                description: String? = nil,
                 author: Author? = nil,
                 url: URL? = nil,
                 image: Image? = nil,
@@ -454,14 +499,15 @@ public struct DiscordEmbed : JSONAble {
         self.image = image
         self.color = color
         self.footer = footer
+        self.fields = fields
     }
 
     init(embedObject: [String: Any]) {
         author = Author(authorObject: embedObject.get("author", or: nil))
-        description = embedObject.get("description", or: "")
+        description = embedObject.get("description", or: nil)
         provider = Provider(providerObject: embedObject.get("provider", or: nil))
-        thumbnail = Thumbnail(thumbnailObject: embedObject.get("provider", or: nil))
-        title = embedObject.get("title", or: "")
+        thumbnail = Thumbnail(thumbnailObject: embedObject.get("thumbnail", or: nil))
+        title = embedObject.get("title", or: nil)
         type = embedObject.get("type", or: "")
         url = URL(string: embedObject.get("url", or: ""))
         image = Image(imageObject: embedObject.get("image", or: nil))
@@ -493,7 +539,7 @@ extension DiscordEmbed.Author {
 
         name = authorObject.get("name", or: "")
         iconUrl = URL(string: authorObject.get("icon_url", or: ""))
-        proxyUrl = URL(string: authorObject.get("proxy_icon_url", or: ""))
+        proxyIconUrl = URL(string: authorObject.get("proxy_icon_url", or: ""))
         url = URL(string: authorObject.get("url", or: ""))
     }
 }
@@ -503,8 +549,8 @@ extension DiscordEmbed.Footer {
         guard let footerObject = footerObject else { return nil }
 
         text = footerObject.get("text", or: "")
-        iconUrl = URL(string: footerObject.get("iconUrl", or: ""))
-        proxyUrl = URL(string: footerObject.get("proxy_icon_url", or: ""))
+        iconUrl = URL(string: footerObject.get("icon_url", or: ""))
+        proxyIconUrl = URL(string: footerObject.get("proxy_icon_url", or: ""))
     }
 }
 
@@ -513,7 +559,7 @@ extension DiscordEmbed.Image {
         guard let imageObject = imageObject else { return nil }
 
         height = imageObject.get("height", or: -1)
-        url = imageObject.get("url", or: "")
+        url = URL(string: imageObject.get("url", or: "")) ?? URL.localhost
         width = imageObject.get("width", or: -1)
     }
 }
@@ -532,7 +578,7 @@ extension DiscordEmbed.Thumbnail {
         guard let thumbnailObject = thumbnailObject else { return nil }
 
         height = thumbnailObject.get("height", or: 0)
-        proxyUrl = URL(string: thumbnailObject.get("proxy_url", or: "")) ?? URL.localhost
+        proxyUrl = URL(string: thumbnailObject.get("proxy_url", or: ""))
         url = URL(string: thumbnailObject.get("url", or: "")) ?? URL.localhost
         width = thumbnailObject.get("width", or: 0)
     }

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -121,14 +121,12 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         self.content = content
         if let embed = embed {
             self.embeds = [embed]
-        }
-        else {
+        } else {
             self.embeds = []
         }
         if let file = file {
             self.files = [file]
-        }
-        else {
+        } else {
             self.files = []
         }
         self.tts = tts
@@ -291,11 +289,11 @@ public struct DiscordEmbed : JSONAble {
         }
 
         /// For testing
-        internal init(name: String, iconURL: URL?, url: URL?, proxyURL: URL?) {
+        init(name: String, iconURL: URL?, url: URL?, proxyIconURL: URL?) {
             self.name = name
             self.iconUrl = iconURL
             self.url = url
-            self.proxyIconUrl = proxyURL
+            self.proxyIconUrl = proxyIconURL
         }
     }
 
@@ -355,10 +353,10 @@ public struct DiscordEmbed : JSONAble {
         }
 
         /// For testing
-        internal init(text: String?, iconURL: URL?, proxyURL: URL?) {
+        init(text: String?, iconURL: URL?, proxyIconURL: URL?) {
             self.text = text
             self.iconUrl = iconURL
-            self.proxyIconUrl = proxyURL
+            self.proxyIconUrl = proxyIconURL
         }
     }
 
@@ -387,7 +385,7 @@ public struct DiscordEmbed : JSONAble {
         }
 
         /// For Testing
-        internal init(url: URL, width: Int, height: Int) {
+        init(url: URL, width: Int, height: Int) {
             self.url = url
             self.width = width
             self.height = height
@@ -436,7 +434,7 @@ public struct DiscordEmbed : JSONAble {
         }
 
         /// For testing
-        internal init(url: URL, width: Int, height: Int, proxyURL: URL?) {
+        init(url: URL, width: Int, height: Int, proxyURL: URL?) {
             self.url = url
             self.width = width
             self.height = height

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -117,10 +117,20 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         - parameter files: The files to send with this message.
         - parameter tts: Whether this message should be text-to-speach.
     */
-    public init(content: String, embeds: [DiscordEmbed] = [], files: [DiscordFileUpload] = [], tts: Bool = false) {
+    public init(content: String, embed: DiscordEmbed? = nil, file: DiscordFileUpload? = nil, tts: Bool = false) {
         self.content = content
-        self.embeds = embeds
-        self.files = files
+        if let embed = embed {
+            self.embeds = [embed]
+        }
+        else {
+            self.embeds = []
+        }
+        if let file = file {
+            self.files = [file]
+        }
+        else {
+            self.files = []
+        }
         self.tts = tts
         self.attachments = []
         self.author = DiscordUser(userObject: [:])
@@ -244,6 +254,7 @@ public struct DiscordAttachment {
 
 /// Represents an embeded entity.
 public struct DiscordEmbed : JSONAble {
+    var shouldIncludeNilsInJSON: Bool { return false }
     // MARK: Nested Types
 
     /// Represents an Embed's author.
@@ -488,7 +499,8 @@ public struct DiscordEmbed : JSONAble {
                 image: Image? = nil,
                 thumbnail: Thumbnail? = nil,
                 color: Int? = nil,
-                footer: Footer? = nil) {
+                footer: Footer? = nil,
+                fields: [Field] = []) {
         self.title = title
         self.author = author
         self.description = description

--- a/Sources/SwiftDiscord/Rest/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordRateLimiter.swift
@@ -151,7 +151,7 @@ public final class DiscordRateLimiter {
 /// Ex. /channels/232184444340011009/messages and /channels/186926276592795659/messages
 /// Are considered different endpoints
 public struct DiscordRateLimitKey : Hashable {
-	/// URL Parts for the purpose of rate limiting.
+    /// URL Parts for the purpose of rate limiting.
     /// Combine all the parts of the URL into a list of which parts exist
     /// Ex. /channels/232184444340011009/messages would be represented by [.channels, .channelID, .messages]
     /// Anything that ends in "ID" represents the existence of a snowflake id, but the actual ID should be

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -53,7 +53,7 @@ class TestDiscordDataStructures : XCTestCase {
 
         let embed1 = DiscordEmbed(title: "Title",
                                   description: "Description",
-                                  author: DiscordEmbed.Author(name: "Author", iconURL: dummyIconA, url: dummyURL, proxyURL: dummyIconB),
+                                  author: DiscordEmbed.Author(name: "Author", iconURL: dummyIconA, url: dummyURL, proxyIconURL: dummyIconB),
                                   url: dummyURL,
                                   image: DiscordEmbed.Image(url: dummyIconA, width: 3245, height: 1493),
                                   thumbnail: DiscordEmbed.Thumbnail(url: dummyIconB, width: 2934, height: 9534, proxyURL: dummyIconA),

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -45,4 +45,56 @@ class TestDiscordDataStructures : XCTestCase {
         XCTAssertEqual(game3.type, game4.type, "Type should survive JSONification")
         XCTAssertEqual(game3.url, game4.url, "URL should survive JSONification")
     }
+
+    func testEmbedJSONification() {
+        let dummyIconA = URL(string: "https://cdn.discordapp.com/embed/avatars/0.png")!
+        let dummyIconB = URL(string: "https://cdn.discordapp.com/embed/avatars/1.png")!
+        let dummyURL = URL(string: "https://discordapp.com")!
+
+        let embed1 = DiscordEmbed(title: "Title",
+                                  description: "Description",
+                                  author: DiscordEmbed.Author(name: "Author", iconURL: dummyIconA, url: dummyURL, proxyURL: dummyIconB),
+                                  url: dummyURL,
+                                  image: DiscordEmbed.Image(url: dummyIconA, width: 3245, height: 1493),
+                                  thumbnail: DiscordEmbed.Thumbnail(url: dummyIconB, width: 2934, height: 9534, proxyURL: dummyIconA),
+                                  color: 423,
+                                  footer: DiscordEmbed.Footer(text: "Footer", iconUrl: dummyIconB),
+                                  fields: [DiscordEmbed.Field(name: "Field Name", value: "Field Value", inline: true)])
+        let embed2 = DiscordEmbed(embedObject: embed1.json)
+        var currentCompare = "embed1 and embed2"
+        func check<T: Equatable>(_ lhs: T?, _ rhs: T?, _ name: String) {
+            XCTAssertEqual(lhs, rhs, "\(name) should survive JSONification (comparing \(currentCompare))")
+        }
+        func compare(_ embed1: DiscordEmbed, _ embed2: DiscordEmbed) {
+            check(embed1.title, embed2.title, "Title")
+            check(embed1.description, embed2.description, "Description")
+            check(embed1.author?.name, embed2.author?.name, "Author name")
+            check(embed1.author?.iconUrl, embed2.author?.iconUrl, "Author icon URL")
+            check(embed1.author?.url, embed2.author?.url, "Author URL")
+            check(embed1.author?.proxyIconUrl, embed2.author?.proxyIconUrl, "Author proxy url")
+            check(embed1.url, embed2.url, "URL")
+            check(embed1.image?.url, embed2.image?.url, "Image URL")
+            check(embed1.image?.width, embed2.image?.width, "Image width")
+            check(embed1.image?.height, embed2.image?.height, "Image height")
+            check(embed1.thumbnail?.url, embed2.thumbnail?.url, "Thumbnail URL")
+            check(embed1.thumbnail?.width, embed2.thumbnail?.width, "Thumbnail width")
+            check(embed1.thumbnail?.height, embed2.thumbnail?.height, "Thumbnail height")
+            check(embed1.thumbnail?.proxyUrl, embed2.thumbnail?.proxyUrl, "Thumbnail proxy URL")
+            check(embed1.color, embed2.color, "Color")
+            check(embed1.footer?.text, embed2.footer?.text, "Footer text")
+            check(embed1.footer?.iconUrl, embed2.footer?.iconUrl, "Footer icon URL")
+            check(embed1.footer?.proxyIconUrl, embed2.footer?.proxyIconUrl, "Footer proxy URL")
+            check(embed1.fields.count, embed2.fields.count, "Field count")
+            check(embed1.fields.first?.name, embed2.fields.first?.name, "Field name")
+            check(embed1.fields.first?.value, embed2.fields.first?.value, "Field value")
+            check(embed1.fields.first?.inline, embed2.fields.first?.inline, "Field inline")
+        }
+        compare(embed1, embed2)
+        let embed3 = DiscordEmbed(author: DiscordEmbed.Author(name: "Author"), image: DiscordEmbed.Image(url: dummyIconA), thumbnail: DiscordEmbed.Thumbnail(url: dummyIconA), footer: DiscordEmbed.Footer(text: "Footer", iconUrl: nil))
+        let embed4 = DiscordEmbed(embedObject: embed3.json)
+        currentCompare = "embed3 and embed4"
+        compare(embed3, embed4)
+        let nilJSONTest = JSON.encodeJSON(embed3.json)!
+        XCTAssertFalse(nilJSONTest.contains("null"), "JSON-encoded embed should not have any null fields")
+    }
 }


### PR DESCRIPTION
Embeds have a lot of fields that come from many different places and I often find myself wanting to initialize them one at a time instead of all-at-once.  It's also not nearly as dangerous to have large amounts of `var` declarations in a swift struct as it is in a swift class or some other languages, since structs are always passed by copy to other functions, and a `let struct = Struct()` will have all its fields be immutable anyways.

Because of this, I would like to make all user-initializeable fields in a DiscordEmbed be mutable so users can initialize their structs piece by piece.

This PR also includes these smaller changes:
- Title and Description fields aren't actually required in an embed, so those are now optional.
- Discord didn't seem to care previously previously, but it seems like a good idea to entirely leave out `nil` fields from the jsonified forms of embeds (instead of encoding them as `key:null`), so that is now done.
- Added a new test for making sure jsonification and de-jsonification of embeds is working
- Made said test pass by fixing these issues:
    - An issue where the DiscordEmbed initializer used `provider` instead of `thumbnail` as the dictionary key for the thumbnail
    - An issue where the DiscordEmbed initializer used `iconUrl` instead of `icon_url` as the dictionary key for the icon URL
    - An optional URL whose init from JSON defaulted it to localhost instead of nil
    - Renamed `proxyUrl` to `proxyIconUrl` to match with Discord's name.  This isn't that important (since users can't add this field to a message) but we might as well make sure it makes the round trip properly.
- Fixed an issue where the message sending system didn't properly send a message that contained a main message, an embed, and an attachment.
- Made `DiscordEmbed.Image.url` a `URL` instead of a `String`
- Made `DiscordMessage.mentionRoles` a `[RoleID]` instead of a `[String]`
- Replaced a few stray tabs with spaces