### PR TITLE
New DiscordShardManager.connect algorithm

### DIFF
--- a/Sources/SwiftDiscord/Gateway/DiscordSharding.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordSharding.swift
@@ -189,8 +189,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
         for (i, shard) in shards.enumerated() {
             let deadline = DispatchTime(secondsFromNow: Double(5 * i))
             DispatchQueue.global().asyncAfter(deadline: deadline) { [weak self, weak shard] in
-                guard let this = self else { return }
-                guard this.get(!this.closed) else { return }
+                guard let this = self, this.get(!this.closed) else { return }
                 shard?.connect()
             }
         }


### PR DESCRIPTION
As it turns out a lot of Foundation methods (including `JSONSerialization`) still autorelease.
While all the memory will eventually be released (currently GCD threads drain their autoreleasepools when they go completely idle), it would make sense to make the process more deterministic by putting `autoreleasepool` blocks around code being dispatched onto another queue that could autorelease (Either due to using `JSONSerialization` or by running user code).

This PR also changes the algorithm for `DiscordShardManager.connect` to not block its thread (threads are expensive and GCD will only allocate a max of 64 threads at one time per process) and instead queue the rest of its work back to the global queue.