### PR TITLE
Multiple file upload support

### DIFF
--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -109,6 +109,12 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         self.client = client
     }
 
+    /// For compatibility
+    @available(*, deprecated, message: "Bots on Discord do not actually have the ability to include more than one embed in a message.  To reflect that, this init has been changed to init(content:embed:files:tts:), which only takes one embed.")
+    public init(content: String, embeds: [DiscordEmbed], files: [DiscordFileUpload] = [], tts: Bool = false) {
+        self.init(content: content, embed: embeds.first, files: files, tts: tts)
+    }
+
     ///
     /// Creates a message that can be used to send.
     ///

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -109,17 +109,6 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         self.client = client
     }
 
-    @available(*, deprecated, message: "SwiftDiscord now supports multiple files per message.\nUse init(content:embed:files:tts:) with an array of files instead.")
-    public init(content: String, embed: DiscordEmbed? = nil, file: DiscordFileUpload?, tts: Bool = false) {
-        let files: [DiscordFileUpload]
-        if let file = file {
-            files = [file]
-        } else {
-            files = []
-        }
-        self.init(content: content, embed: embed, files: files, tts: tts)
-    }
-
     ///
     /// Creates a message that can be used to send.
     ///

--- a/Sources/SwiftDiscord/DiscordUtils.swift
+++ b/Sources/SwiftDiscord/DiscordUtils.swift
@@ -57,23 +57,30 @@ extension URL {
     static let localhost = URL(string: "http://localhost/")!
 }
 
-func createMultipartBody(fields: [String: String], file: DiscordFileUpload?) -> (boundary: String, body: Data) {
+func createMultipartBody(json: [String: Any], files: [DiscordFileUpload]) -> (boundary: String, body: Data) {
     let boundary = "Boundary-\(UUID())"
+    let crlf = "\r\n".data(using: .utf8)!
     var body = Data()
 
-    for (field, value) in fields {
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"\(field)\"\r\n\r\n".data(using: .utf8)!)
-        body.append("\(value)\r\n".data(using: .utf8)!)
-    }
+    let encodedJson = JSON.encodeJSONData(json) ?? Data()
 
-    if let file = file {
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append("Content-Disposition: form-data; name=\"payload_json\"\r\n".data(using: .utf8)!)
+    body.append("Content-Type: application/json\r\n".data(using: .utf8)!)
+    body.append("Content-Length: \(encodedJson.count)\r\n\r\n".data(using: .utf8)!)
+    body.append(encodedJson)
+    body.append(crlf)
+
+    for (index, file) in files.enumerated() {
         body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(file.filename)\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: \(file.mimeType)\r\n\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\(index)\"; filename=\"\(file.filename)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: \(file.mimeType)\r\n".data(using: .utf8)!)
+        body.append("Content-Length: \(file.data.count)\r\n\r\n".data(using: .utf8)!)
         body.append(file.data)
-        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        body.append(crlf)
     }
+    
+    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 
     return (boundary, body)
 }


### PR DESCRIPTION
I feel a little bad about reintroducing `DiscordMessage.init(files: [DiscordFileUpload])` after removing it in 5.0.0, but it now actually does things with all the files!  (I realized this must be possible when I noticed the android client could do it)
This also includes a shim for the old `init(file: DiscordFileUpload?)` with a deprecated message so we can wait for a more major change to bump the major version number.