### PR TITLE
Use named parameters in get messages instead of an enum array

### DIFF
--- a/Sources/SwiftDiscord/DiscordSnowflakeID.swift
+++ b/Sources/SwiftDiscord/DiscordSnowflakeID.swift
@@ -34,7 +34,7 @@ public struct Snowflake {
     }
 
     /// Initialize from an optional string (returns nil if the input was nil or if it failed to initialize)
-    init?(_ optionalString: String?) {
+    public init?(_ optionalString: String?) {
         guard let string = optionalString else { return nil }
         guard let snowflake = Snowflake(string) else { return nil }
         self = snowflake

--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -540,6 +540,7 @@ public extension DiscordEndpoint {
         /// Get message options.
         ///
         /// after, around and before are mutually exclusive. They shouldn't be in the same get request
+        @available(*, deprecated, message: "Only used for the deprecated getMessages(channel:options:callback:) method")
         public enum GetMessage {
             /// The message to get other messages after.
             case after(DiscordMessage)
@@ -552,6 +553,29 @@ public extension DiscordEndpoint {
 
             /// The number of messages to get.
             case limit(Int)
+        }
+
+        /// Options for getting messages
+        public enum MessageSelection {
+            /// Messages after the given ID
+            case after(MessageID)
+
+            /// Messages around the given ID
+            case around(MessageID)
+
+            /// Messages before the given ID
+            case before(MessageID)
+
+            internal var messageParam: (String, MessageID) {
+                switch self {
+                case let .after(message):
+                    return ("after", message)
+                case let .around(message):
+                    return ("around", message)
+                case let .before(message):
+                    return ("before", message)
+                }
+            }
         }
 
         /// Guild create channel options.

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -203,21 +203,36 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
-    public func getMessages(for channelId: ChannelID, options: [DiscordEndpoint.Options.GetMessage] = [],
+    @available(*, deprecated, message: "Replaced with getMessages(channel:selection:limit:callback:)")
+    public func getMessages(for channelId: ChannelID, options: [DiscordEndpoint.Options.GetMessage],
                             callback: @escaping ([DiscordMessage]) -> ()) {
-        var getParams: [String: String] = [:]
-
+        var selection: DiscordEndpoint.Options.MessageSelection? = nil
+        var limit: Int? = nil
         for option in options {
             switch option {
             case let .after(message):
-                getParams["after"] = String(describing: message.id)
+                selection = .after(message.id)
             case let .around(message):
-                getParams["around"] = String(describing: message.id)
+                selection = .around(message.id)
             case let .before(message):
-                getParams["before"] = String(describing: message.id)
+                selection = .before(message.id)
             case let .limit(number):
-                getParams["limit"] = String(number)
+                limit = number
             }
+        }
+        getMessages(for: channelId, selection: selection, limit: limit, callback: callback)
+    }
+
+    /// Default implementation
+    public func getMessages(for channelId: ChannelID, selection: DiscordEndpoint.Options.MessageSelection? = nil,
+                            limit: Int? = nil, callback: @escaping ([DiscordMessage]) -> ()) {
+        var getParams: [String: String] = [:]
+
+        if let (selectionType, selectionMessage) = selection?.messageParam {
+            getParams[selectionType] = String(describing: selectionMessage)
+        }
+        if let limit = limit {
+            getParams["limit"] = String(limit)
         }
 
         let requestCallback: DiscordRequestCallback = {data, response, error in

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer.swift
@@ -153,7 +153,19 @@ public protocol DiscordEndpointConsumer {
     /// - parameter options: An array of `DiscordEndpointOptions.GetMessage` options
     /// - parameter callback: The callback function, taking an array of `DiscordMessages`
     ///
+    @available(*, deprecated, message: "Replaced with getMessages(channel:selection:limit:callback:)")
     func getMessages(for channel: ChannelID, options: [DiscordEndpoint.Options.GetMessage],
+                     callback: @escaping ([DiscordMessage]) -> ())
+
+    ///
+    /// Gets a group of messages according to the specified options.
+    ///
+    /// - parameter for: The channel that we are getting on
+    /// - parameter selection: The selection to use get messages with.  A nil value will use Discord's default, which will get the most recent messages in the channel
+    /// - parameter limit: The maximum number of messages to fetch.  Should be in the range 1...100.  A nil value will use Discord's default, which is currently 50.
+    /// - parameter callback: The callback function, taking an array of `DiscordMessages`
+    ///
+    func getMessages(for channel: ChannelID, selection: DiscordEndpoint.Options.MessageSelection?, limit: Int?,
                      callback: @escaping ([DiscordMessage]) -> ())
 
     ///


### PR DESCRIPTION
Changes:
- Adds `getMessages(channel:selection:limit:callback:)` method
- Deprecates `getMessages(channel:options:callback:)`
- The new getMessages uses `MessageID`s instead of `DiscordMessage`s.  Because of how `before` and `after` work (they don't include the specified message in their return), it can sometimes be useful to add/subtract one from the Message ID to include that message in the array.  This is much easier if you only have to give a MessageID.
- Makes the convenience init `Snowflake.init?(optionalString:)` public (it probably should have been from the start)