### PR TITLE
Embed timestamp support

### DIFF
--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -346,7 +346,7 @@ public struct DiscordEmbed : JSONAble {
         /// - parameter text: The text of this field.
         /// - parameter iconUrl: The iconUrl of this field.
         ///
-        public init(text: String?, iconUrl: URL?) {
+        public init(text: String?, iconUrl: URL? = nil) {
             self.text = text
             self.iconUrl = iconUrl
             self.proxyIconUrl = nil
@@ -593,6 +593,16 @@ extension DiscordEmbed.Thumbnail {
         proxyUrl = URL(string: thumbnailObject.get("proxy_url", or: ""))
         url = URL(string: thumbnailObject.get("url", or: "")) ?? URL.localhost
         width = thumbnailObject.get("width", or: 0)
+    }
+}
+
+extension DiscordEmbed.Video {
+    init?(videoObject: [String: Any]?) {
+        guard let videoObject = videoObject else { return nil }
+
+        height = videoObject.get("height", or: 0)
+        url = videoObject.get("url", as: String.self).flatMap(URL.init) ?? URL.localhost
+        width = videoObject.get("width", or: 0)
     }
 }
 

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -442,6 +442,21 @@ public struct DiscordEmbed : JSONAble {
         }
     }
 
+    /// Represents the video of an embed.
+    /// Note: Discord does not accept these, so they are read-only
+    public struct Video : JSONAble {
+        var shouldIncludeNilsInJSON: Bool { return false }
+
+        /// The height of this video
+        public let height: Int
+
+        /// The url for this video
+        public let url: URL
+
+        /// The width of this video
+        public let width: Int
+    }
+
     // MARK: Properties
 
     /// The author of this embed.
@@ -465,6 +480,9 @@ public struct DiscordEmbed : JSONAble {
     /// The thumbnail of this embed.
     public var thumbnail: Thumbnail?
 
+    /// The timestamp of this embed.
+    public var timestamp: Date?
+
     /// The title of this embed.
     public var title: String?
 
@@ -473,6 +491,10 @@ public struct DiscordEmbed : JSONAble {
 
     /// The url of this embed.
     public var url: URL?
+
+    /// The video of this embed.
+    /// This is read-only, as bots cannot embed videos
+    public var video: Video?
 
     /// The embed's fields
     public var fields: [Field]
@@ -487,6 +509,7 @@ public struct DiscordEmbed : JSONAble {
     /// - parameter author: The author of this embed.
     /// - parameter url: The url for this embed, if there is one.
     /// - parameter image: The image for the embed, if there is one.
+    /// - parameter timestamp: The timestamp of this embed, if there is one.
     /// - parameter thumbnail: The thumbnail of this embed, if there is one.
     /// - parameter color: The color of this embed.
     /// - parameter footer: The footer for this embed, if there is one.
@@ -497,6 +520,7 @@ public struct DiscordEmbed : JSONAble {
                 author: Author? = nil,
                 url: URL? = nil,
                 image: Image? = nil,
+                timestamp: Date? = nil,
                 thumbnail: Thumbnail? = nil,
                 color: Int? = nil,
                 footer: Footer? = nil,
@@ -506,6 +530,7 @@ public struct DiscordEmbed : JSONAble {
         self.description = description
         self.provider = nil
         self.thumbnail = thumbnail
+        self.timestamp = timestamp
         self.type = "rich"
         self.url = url
         self.image = image
@@ -518,6 +543,7 @@ public struct DiscordEmbed : JSONAble {
         author = Author(authorObject: embedObject.get("author", or: nil))
         description = embedObject.get("description", or: nil)
         provider = Provider(providerObject: embedObject.get("provider", or: nil))
+        timestamp = embedObject.get("timestamp", as: String.self).flatMap(DiscordDateFormatter.format)
         thumbnail = Thumbnail(thumbnailObject: embedObject.get("thumbnail", or: nil))
         title = embedObject.get("title", or: nil)
         type = embedObject.get("type", or: "")
@@ -526,6 +552,7 @@ public struct DiscordEmbed : JSONAble {
         fields = Field.fieldsFromArray(embedObject.get("fields", or: []))
         color = embedObject.get("color", or: nil)
         footer = Footer(footerObject: embedObject.get("footer", or: nil))
+        video = Video(videoObject: embedObject.get("video", or: nil))
     }
 
     static func embedsFromArray(_ embedsArray: [[String: Any]]) -> [DiscordEmbed] {

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -80,6 +80,11 @@ extension URL : JSONRepresentable {
         return absoluteString
     }
 }
+extension Date : JSONRepresentable {
+    func jsonValue() throws -> JSONRepresentable {
+        return DiscordDateFormatter.string(from: self)
+    }
+}
 
 extension JSONRepresentable {
     func jsonValue() throws -> JSONRepresentable {

--- a/Sources/SwiftDiscord/DiscordUtils.swift
+++ b/Sources/SwiftDiscord/DiscordUtils.swift
@@ -25,9 +25,13 @@ enum Either<L, R> {
 
 typealias JSONArray = [[String: Any]]
 
-extension Dictionary {
+extension Dictionary where Value == Any {
     func get<T>(_ value: Key, or default: T) -> T {
         return self[value] as? T ?? `default`
+    }
+
+    func get<T>(_ value: Key, as type: T.Type) -> T? {
+        return self[value] as? T
     }
 }
 
@@ -97,6 +101,10 @@ class DiscordDateFormatter {
 
     static func format(_ string: String) -> Date? {
         return formatter.RFC3339DateFormatter.date(from: string)
+    }
+
+    static func string(from date: Date) -> String {
+        return formatter.RFC3339DateFormatter.string(from: date)
     }
 }
 

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -51,15 +51,18 @@ public class TestDiscordDataStructures : XCTestCase {
         let dummyIconB = URL(string: "https://cdn.discordapp.com/embed/avatars/1.png")!
         let dummyURL = URL(string: "https://discordapp.com")!
 
-        let embed1 = DiscordEmbed(title: "Title",
-                                  description: "Description",
-                                  author: DiscordEmbed.Author(name: "Author", iconURL: dummyIconA, url: dummyURL, proxyIconURL: dummyIconB),
-                                  url: dummyURL,
-                                  image: DiscordEmbed.Image(url: dummyIconA, width: 3245, height: 1493),
-                                  thumbnail: DiscordEmbed.Thumbnail(url: dummyIconB, width: 2934, height: 9534, proxyURL: dummyIconA),
-                                  color: 423,
-                                  footer: DiscordEmbed.Footer(text: "Footer", iconUrl: dummyIconB),
-                                  fields: [DiscordEmbed.Field(name: "Field Name", value: "Field Value", inline: true)])
+        let embed1 = DiscordEmbed(
+            title: "Title",
+            description: "Description",
+            author: DiscordEmbed.Author(name: "Author", iconURL: dummyIconA, url: dummyURL, proxyIconURL: dummyIconB),
+            url: dummyURL,
+            image: DiscordEmbed.Image(url: dummyIconA, width: 3245, height: 1493),
+            timestamp: Date(timeIntervalSince1970: 429384.25), // Must be losslessly convertible to RFC3339
+            thumbnail: DiscordEmbed.Thumbnail(url: dummyIconB, width: 2934, height: 9534, proxyURL: dummyIconA),
+            color: 423,
+            footer: DiscordEmbed.Footer(text: "Footer", iconUrl: dummyIconB),
+            fields: [DiscordEmbed.Field(name: "Field Name", value: "Field Value", inline: true)]
+        )
         let embed2 = DiscordEmbed(embedObject: embed1.json)
         var currentCompare = "embed1 and embed2"
         func check<T: Equatable>(_ lhs: T?, _ rhs: T?, _ name: String) {
@@ -76,6 +79,7 @@ public class TestDiscordDataStructures : XCTestCase {
             check(embed1.image?.url, embed2.image?.url, "Image URL")
             check(embed1.image?.width, embed2.image?.width, "Image width")
             check(embed1.image?.height, embed2.image?.height, "Image height")
+            check(embed1.timestamp, embed2.timestamp, "Timestamp")
             check(embed1.thumbnail?.url, embed2.thumbnail?.url, "Thumbnail URL")
             check(embed1.thumbnail?.width, embed2.thumbnail?.width, "Thumbnail width")
             check(embed1.thumbnail?.height, embed2.thumbnail?.height, "Thumbnail height")

--- a/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
@@ -23,6 +23,7 @@ public class TestDiscordPermissions : XCTestCase {
 
         XCTAssertEqual(channel.permissionOverwrites.count, roleOverwrites.count, "There should be the same number of permission overwrites in this channel as we put in")
 
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[2], .readMessageHistory), "@everyone role should be applied to all members")
         XCTAssertTrue(channel.canMember(permissionsTestMembers[0], .sendMessages), "Owner should override all permissions")
         XCTAssertTrue(channel.canMember(permissionsTestMembers[1], .readMessages), "Admin role should override all permissions")
         XCTAssertTrue(channel.canMember(permissionsTestMembers[4], .addReactions), "An allow override should go over a deny of the same type")
@@ -58,6 +59,7 @@ public class TestDiscordPermissions : XCTestCase {
     }
 
     let roleOverwrites = [
+        DiscordPermissionOverwrite(id: GuildID(testGuild.get("id", as: String.self))!, type: .role, allow: [], deny: .readMessageHistory),
         DiscordPermissionOverwrite(id: permissionsTestRoles[3].id, type: .role, allow: [], deny: [.sendMessages, .addReactions]),
         DiscordPermissionOverwrite(id: permissionsTestRoles[2].id, type: .role, allow: .addReactions, deny: []),
         DiscordPermissionOverwrite(id: permissionsTestRoles[0].id, type: .role, allow: [], deny: .readMessages),


### PR DESCRIPTION
- Adds support for timestamps in discord embeds
- Adds support for reading the video tag in discord embeds (I have no idea when it gets used, but it was listed in the documentation so I thought I'd include it)
- Adds a default of `nil` to the icon URL in `DiscordEmbed.Footer`
- Adds a test for the previously added @​everyone permission change