### PR TITLE
Switch to Encodable for JSONification

### DIFF
--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -317,7 +317,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     ///
     open func setPresence(_ presence: DiscordPresenceUpdate) {
         shardManager.sendPayload(DiscordGatewayPayload(code: .gateway(.statusUpdate),
-                                                       payload: .object(presence.json)),
+                                                       payload: .customEncodable(presence)),
                                  onShard: 0)
     }
 

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -21,15 +21,24 @@ enum JSON {
     case array([Any])
     case object([String: Any])
 
-    static func encodeJSONData(_ object: Any) -> Data? {
-        return try? JSONSerialization.data(withJSONObject: object)
+    static func encodeJSONData<T: Encodable>(_ object: T) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .formatted(DiscordDateFormatter.rfc3339DateFormatter)
+        if let dictionary = object as? [String: Any] {
+            guard let encodableDic = dictionary as? [String: Encodable] else { return nil }
+            return try? encoder.encode(GenericEncodableDictionary(encodableDic))
+        }
+        if let array = object as? [Any] {
+            guard let encodableArray = array as? [Encodable] else { return nil }
+            return try? encoder.encode(GenericEncodableArray(encodableArray))
+        }
+        return try? encoder.encode(object)
     }
-
-    static func encodeJSON(_ object: Any) -> String? {
-        guard let data = encodeJSONData(object) else { return nil }
-        return String(data: data, encoding: .utf8)
+    
+    static func encodeJSON<T: Encodable>(_ object: T) -> String? {
+        return encodeJSONData(object).flatMap({ String(data: $0, encoding: .utf8) })
     }
-
+    
     static func decodeJSON(_ string: String) -> JSON? {
         guard let data = string.data(using: .utf8, allowLossyConversion: false) else { return nil }
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) else { return nil }
@@ -74,117 +83,3 @@ enum JSONError : Error {
     case collectionError // Thrown when elements in the collection are not representable by json
 }
 
-protocol JSONRepresentable {
-    func jsonValue() throws -> JSONRepresentable
-}
-
-protocol JSONAble : JSONRepresentable {
-    var shouldIncludeNilsInJSON: Bool { get }
-    var json: [String: JSONRepresentable] { get }
-}
-
-extension Array : JSONRepresentable { }
-extension Dictionary : JSONRepresentable { }
-extension Double : JSONRepresentable { }
-extension Int : JSONRepresentable { }
-extension NSNull : JSONRepresentable { }
-extension Optional : JSONRepresentable { }
-extension String : JSONRepresentable { }
-extension Bool : JSONRepresentable { }
-extension URL : JSONRepresentable {
-    func jsonValue() -> JSONRepresentable {
-        return absoluteString
-    }
-}
-extension Date : JSONRepresentable {
-    func jsonValue() throws -> JSONRepresentable {
-        return DiscordDateFormatter.string(from: self)
-    }
-}
-
-extension JSONRepresentable {
-    func jsonValue() throws -> JSONRepresentable {
-        if self is [AnyHashable: Any] {
-            guard let dict = self as? [String: JSONRepresentable] else { throw JSONError.collectionError }
-
-            return try dict.reduce([String: Any](), {cur, keyValue in
-                var cur = cur
-
-                cur[keyValue.key.snakecase] = try keyValue.value.jsonValue()
-
-                return cur
-            })
-        } else if self is [Any] {
-            guard let array = self as? [JSONRepresentable] else { throw JSONError.collectionError }
-
-            return try array.map({ try $0.jsonValue() })
-        } else if let optionalValue = possibleOptionalRepresentation(of: self) {
-            return optionalValue
-        }
-
-        return self
-    }
-}
-
-// For checking if a value should be included in JSON
-fileprivate protocol Emptyable {
-    var isEmpty: Bool { get }
-}
-extension Optional : Emptyable {
-    fileprivate var isEmpty: Bool {
-        switch self {
-        case .none: return true
-        case .some: return false
-        }
-    }
-}
-extension Array : Emptyable {}
-extension Dictionary : Emptyable {}
-
-extension JSONAble {
-    var shouldIncludeNilsInJSON: Bool { return true }
-
-    var json: [String: JSONRepresentable] {
-        var json = [String: JSONRepresentable]()
-
-        let mirror = Mirror(reflecting: self)
-
-        for case let (name?, value) in mirror.children {
-            guard shouldIncludeNilsInJSON || (value as? Emptyable)?.isEmpty != true else {
-                continue
-            }
-
-            if let nested = value as? JSONAble {
-                json[name.snakecase] = nested.json
-            } else if let sendable = value as? JSONRepresentable {
-                do {
-                    json[name.snakecase] = try sendable.jsonValue()
-                } catch {
-                    DefaultDiscordLogger.Logger.error("Couldn't json property \(name)", type: "JSONAble")
-                }
-            }
-        }
-
-        return json
-    }
-
-    func jsonValue() -> JSONRepresentable {
-        return json
-    }
-}
-
-private func possibleOptionalRepresentation(of something: Any) -> JSONRepresentable? {
-    // Workaround for not being able to do
-    // `extension Optional: JSONRepresentable where Wrapped: JSONRepresentable`
-    let valueMirror = Mirror(reflecting: something)
-    guard valueMirror.displayStyle == .optional else { return nil }
-    guard valueMirror.children.count == 1 else { return NSNull() } // If no children, this is .none
-    // Make sure the wrapped type is representable in json
-    guard case let (_, optionalValue as JSONRepresentable) = valueMirror.children.first! else { return nil }
-
-    if let jsonable = optionalValue as? JSONAble {
-        return jsonable.json
-    }
-
-    return try? optionalValue.jsonValue()
-}

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -27,12 +27,12 @@ enum JSON {
         if let dictionary = object as? [String: Any] {
             guard let encodableDic = dictionary as? [String: Encodable] else { return nil }
             return try? encoder.encode(GenericEncodableDictionary(encodableDic))
-        }
-        if let array = object as? [Any] {
+        } else if let array = object as? [Any] {
             guard let encodableArray = array as? [Encodable] else { return nil }
             return try? encoder.encode(GenericEncodableArray(encodableArray))
+        } else {
+            return try? encoder.encode(object)
         }
-        return try? encoder.encode(object)
     }
     
     static func encodeJSON<T: Encodable>(_ object: T) -> String? {

--- a/Sources/SwiftDiscord/DiscordSnowflakeID.swift
+++ b/Sources/SwiftDiscord/DiscordSnowflakeID.swift
@@ -108,12 +108,32 @@ extension Snowflake {
 
 // MARK: Snowflake Conformances
 
-/// Snowflake conformance to JSONRepresentable
-extension Snowflake : JSONRepresentable {
-    func jsonValue() -> JSONRepresentable {
-        // Snowflakes should be put into JSON as Strings
-        return self.description
+extension Snowflake: Codable {
+    /// Set this key to true on an encoder to encode Snowflakes as UInt64s instead of Strings.
+    /// This will save space in binary encoders like binary plists, but will cause encoded JSON to be
+    /// incompatible with Discord. Since JSON isn't a binary encoding, it won't save much space there anyways.
+    public static let encodeAsUInt64 = CodingUserInfoKey(rawValue: "snowflakeAsUInt64")!
+    public init(from decoder: Decoder) throws {
+        do {
+            let intForm = try UInt64(from: decoder)
+            self = Snowflake(intForm)
+        }
+        catch _ {
+            let stringForm = try String(from: decoder)
+            guard let snowflake = Snowflake(stringForm) else {
+                throw DecodingError.typeMismatch(Snowflake.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Failed to convert decoded string into a snowflake"))
+            }
+            self = snowflake
+        }
     }
+    public func encode(to encoder: Encoder) throws {
+        if encoder.userInfo[Snowflake.encodeAsUInt64] as? Bool ?? false {
+            try self.rawValue.encode(to: encoder)
+        } else {
+            try self.description.encode(to: encoder)
+        }
+    }
+    
 }
 
 /// Snowflake conformance to ExpressibleByIntegerLiteral

--- a/Sources/SwiftDiscord/DiscordSnowflakeID.swift
+++ b/Sources/SwiftDiscord/DiscordSnowflakeID.swift
@@ -117,11 +117,13 @@ extension Snowflake: Codable {
         do {
             let intForm = try UInt64(from: decoder)
             self = Snowflake(intForm)
-        }
-        catch _ {
-            let stringForm = try String(from: decoder)
-            guard let snowflake = Snowflake(stringForm) else {
-                throw DecodingError.typeMismatch(Snowflake.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Failed to convert decoded string into a snowflake"))
+        } catch {
+            guard let snowflake = Snowflake(try String(from: decoder)) else {
+                let context = DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Failed to convert decoded string into a snowflake"
+                )
+                throw DecodingError.typeMismatch(Snowflake.self, context)
             }
             self = snowflake
         }

--- a/Sources/SwiftDiscord/DiscordUtils.swift
+++ b/Sources/SwiftDiscord/DiscordUtils.swift
@@ -91,29 +91,6 @@ struct GenericEncodableDictionary : Encodable {
     }
 }
 
-
-extension String {
-    var snakecase: String {
-        var ret = ""
-
-        for index in characters.indices {
-            let stringChar = String(self[index])
-
-            if stringChar.uppercased() == stringChar {
-                if index != startIndex {
-                    ret += "_"
-                }
-
-                ret += stringChar.lowercased()
-            } else {
-                ret += stringChar
-            }
-        }
-
-        return ret
-    }
-}
-
 extension URL {
     static let localhost = URL(string: "http://localhost/")!
 }

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -139,7 +139,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             extraHeaders[.auditReason] = modifyReason
         }
 
-        guard let contentData = JSON.encodeJSONData(permissionOverwrite.json) else { return }
+        guard let contentData = JSON.encodeJSONData(permissionOverwrite) else { return }
 
         rateLimiter.executeRequest(endpoint: .channelPermission(channel: channelId, overwrite: permissionOverwrite.id),
                                    token: token,

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Guilds.swift
@@ -41,7 +41,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                    options: [DiscordEndpoint.Options.GuildCreateChannel],
                                    reason: String? = nil,
                                    callback: ((DiscordGuildChannel?) -> ())? = nil) {
-        var createJSON: [String: Any] = [:]
+        var createJSON: [String: Encodable] = [:]
         var extraHeaders = [DiscordHeader: String]()
 
         if let modifyReason = reason {
@@ -55,7 +55,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             case let .name(name):
                 createJSON["name"] = name
             case let .permissionOverwrites(overwrites):
-                createJSON["permission_overwrites"] = overwrites.map({ $0.json })
+                createJSON["permission_overwrites"] = overwrites
             case let .type(type):
                 createJSON["type"] = type.rawValue
             case let .userLimit(limit):
@@ -63,7 +63,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             }
         }
 
-        guard let contentData = JSON.encodeJSONData(createJSON) else { return }
+        guard let contentData = JSON.encodeJSONData(GenericEncodableDictionary(createJSON)) else { return }
 
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(channel)? = JSON.jsonFromResponse(data: data, response: response) else {
@@ -423,7 +423,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                 on guildId: GuildID,
                                 reason: String? = nil,
                                 callback: ((DiscordRole?) -> ())? = nil) {
-        guard let contentData = JSON.encodeJSONData(role.json) else { return }
+        guard let contentData = JSON.encodeJSONData(role) else { return }
         var extraHeaders = [DiscordHeader: String]()
 
         if let modifyReason = reason {

--- a/Sources/SwiftDiscord/User/DiscordPermission.swift
+++ b/Sources/SwiftDiscord/User/DiscordPermission.swift
@@ -16,7 +16,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 /// Represents a Discord Permission. Calculating Permissions involves bitwise operations.
-public struct DiscordPermission : OptionSet, JSONRepresentable {
+public struct DiscordPermission : OptionSet, Encodable {
     public let rawValue: Int
 
     /// This user can create invites.
@@ -90,28 +90,20 @@ public struct DiscordPermission : OptionSet, JSONRepresentable {
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-
-    func jsonValue() throws -> JSONRepresentable {
-        return self.rawValue
-    }
 }
 
 /// Represents a permission overwrite type for a channel.
-public enum DiscordPermissionOverwriteType : String, JSONRepresentable {
+public enum DiscordPermissionOverwriteType : String, Encodable {
     /// A role overwrite.
     case role = "role"
     /// A member overwrite.
     case member = "member"
-
-    func jsonValue() -> JSONRepresentable {
-        return rawValue
-    }
 }
 
 /// Represents a permission overwrite for a channel.
 ///
 /// The `allow` and `deny` properties are bit fields.
-public struct DiscordPermissionOverwrite : JSONAble {
+public struct DiscordPermissionOverwrite : Encodable {
     // MARK: Properties
 
     /// The snowflake id of this permission overwrite.

--- a/Sources/SwiftDiscord/User/DiscordPresence.swift
+++ b/Sources/SwiftDiscord/User/DiscordPresence.swift
@@ -16,25 +16,16 @@
 // DEALINGS IN THE SOFTWARE.
 
 /// Represents a game type.
-public enum DiscordGameType : Int, JSONRepresentable {
+public enum DiscordGameType : Int, Encodable {
     /// A regular game.
-    case game
+    case game = 0
 
     /// A stream.
-    case stream
-
-    func jsonValue() -> JSONRepresentable {
-        switch self {
-        case .game:
-            return 0
-        case .stream:
-            return 1
-        }
-    }
+    case stream = 1
 }
 
 /// Represents a game
-public struct DiscordGame : JSONAble {
+public struct DiscordGame : Encodable {
     // MARK: Properties
 
     /// The name of the game.
@@ -163,7 +154,7 @@ public struct DiscordPresence {
 
 
 /// Used to send updates to Discord about our presence.
-public struct DiscordPresenceUpdate : JSONAble {
+public struct DiscordPresenceUpdate : Encodable {
     // MARK: Properties
 
     /// The time we've been idle for. Nil if not idle

--- a/Sources/SwiftDiscord/User/DiscordRole.swift
+++ b/Sources/SwiftDiscord/User/DiscordRole.swift
@@ -16,7 +16,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 /// Represents a Discord role.
-public struct DiscordRole : JSONAble, Equatable {
+public struct DiscordRole : Encodable, Equatable {
     // MARK: Properties
 
     /// The snowflake id of the role.

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -132,6 +132,43 @@ public class TestDiscordDataStructures : XCTestCase {
         XCTAssertEqual(payloadData[5], DiscordGatewayPayloadData.integer(-1), "Discord Gateway Payload should unwrap -1")
     }
 
+    func testDiscordGatewayPayload() {
+        func testRunner(data: DiscordGatewayPayloadData, test: (Any?) -> ()) {
+            let payload = DiscordGatewayPayload(code: .gateway(.identify), payload: data, sequenceNumber: 9, name: "hi")
+            let json = payload.createPayloadString()!
+            let object = try! JSONSerialization.jsonObject(with: json.data(using: .utf8)!, options: []) as! [String: Any]
+            XCTAssertEqual(object["op"] as? Int, payload.code.rawCode)
+            XCTAssertEqual(object["s"] as? Int, payload.sequenceNumber)
+            XCTAssertEqual(object["t"] as? String, payload.name)
+            test(object["d"])
+        }
+        testRunner(data: .bool(true)) { item in
+            XCTAssertEqual(item as? Bool, true)
+        }
+        testRunner(data: .bool(false)) { item in
+            XCTAssertEqual(item as? Bool, false)
+        }
+        testRunner(data: .integer(8)) { item in
+            XCTAssertEqual(item as? Int, 8)
+        }
+        testRunner(data: .object(["hello": 4, "yay": DiscordGame(name: "A Game", type: .stream)])) { item in
+            let item = item as! [String: Any]
+            XCTAssertEqual(item["hello"] as? Int, 4)
+            XCTAssertNotNil(item["yay"])
+            let game = DiscordGame(gameObject: item["yay"] as? [String: Any])
+            XCTAssertEqual(game?.name, "A Game")
+            XCTAssertEqual(game?.type, .stream)
+        }
+        let perms = DiscordPermissionOverwrite(id: 95352, type: .member, allow: [.addReactions, .attachFiles], deny: [.changeNickname, .manageChannels])
+        testRunner(data: .customEncodable(perms)) { (item) in
+            let newPerms = DiscordPermissionOverwrite(permissionOverwriteObject: item as? [String: Any] ?? [:])
+            XCTAssertEqual(newPerms.id, perms.id)
+            XCTAssertEqual(newPerms.type, perms.type)
+            XCTAssertEqual(newPerms.allow, perms.allow)
+            XCTAssertEqual(newPerms.deny, perms.deny)
+        }
+    }
+
     public static var allTests: [(String, (TestDiscordDataStructures) -> () -> ())] {
         return [
             ("testRoleJSONification", testRoleJSONification),

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -18,10 +18,16 @@ extension DiscordGatewayPayloadData: Equatable {
     }
 }
 
+func roundTripEncode<T: Encodable>(_ item: T) -> [String: Any] {
+    let json = JSON.encodeJSONData(item)!
+    return try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
+}
+
 public class TestDiscordDataStructures : XCTestCase {
+
     func testRoleJSONification() {
         let role1 = DiscordRole(id: 324, color: 43, hoist: false, managed: true, mentionable: false, name: "Test Role", permissions: [.addReactions], position: 4)
-        let role2 = DiscordRole(roleObject: role1.json)
+        let role2 = DiscordRole(roleObject: roundTripEncode(role1))
 
         XCTAssertEqual(role1.id, role2.id, "Role ID should survive JSONification")
         XCTAssertEqual(role1.color, role2.color, "Color should survive JSONification")
@@ -35,22 +41,22 @@ public class TestDiscordDataStructures : XCTestCase {
 
     func testPermissionOverwriteJSONification() {
         let overwrite1 = DiscordPermissionOverwrite(id: 5234, type: .member, allow: [.changeNickname, .voice], deny: [.manageChannels])
-        let overwrite2 = DiscordPermissionOverwrite(permissionOverwriteObject: overwrite1.json)
+        let overwrite2 = DiscordPermissionOverwrite(permissionOverwriteObject: roundTripEncode(overwrite1))
 
         XCTAssertEqual(overwrite1.id, overwrite2.id, "Permission Overwrite ID should survive JSONification")
         XCTAssertEqual(overwrite1.type, overwrite2.type, "Type should survive JSONification")
         XCTAssertEqual(overwrite1.allow, overwrite2.allow, "Allow should survive JSONification")
         XCTAssertEqual(overwrite1.deny, overwrite2.deny, "Deny should survive JSONification")
         let overwrite3 = DiscordPermissionOverwrite(id: 934, type: .role, allow: [], deny: [])
-        let overwrite4 = DiscordPermissionOverwrite(permissionOverwriteObject: overwrite3.json)
+        let overwrite4 = DiscordPermissionOverwrite(permissionOverwriteObject: roundTripEncode(overwrite3))
         XCTAssertEqual(overwrite3.type, overwrite4.type, "Type should survive JSONification")
     }
 
     func testGameJSONification() {
         let game1 = DiscordGame(name: "Game", type: .game)
-        let game2 = DiscordGame(gameObject: game1.json)!
+        let game2 = DiscordGame(gameObject: roundTripEncode(game1))!
         let game3 = DiscordGame(name: "Another Game", type: .stream, url: "http://www.twitch.tv/person")
-        let game4 = DiscordGame(gameObject: game3.json)!
+        let game4 = DiscordGame(gameObject: roundTripEncode(game3))!
         XCTAssertEqual(game1.name, game2.name, "Name should survive JSONification")
         XCTAssertEqual(game1.type, game2.type, "Type should survive JSONification")
         XCTAssertEqual(game1.url, game2.url, "Nil URL should survive JSONification")
@@ -76,7 +82,7 @@ public class TestDiscordDataStructures : XCTestCase {
             footer: DiscordEmbed.Footer(text: "Footer", iconUrl: dummyIconB),
             fields: [DiscordEmbed.Field(name: "Field Name", value: "Field Value", inline: true)]
         )
-        let embed2 = DiscordEmbed(embedObject: embed1.json)
+        let embed2 = DiscordEmbed(embedObject: roundTripEncode(embed1))
         var currentCompare = "embed1 and embed2"
         func check<T: Equatable>(_ lhs: T?, _ rhs: T?, _ name: String) {
             XCTAssertEqual(lhs, rhs, "\(name) should survive JSONification (comparing \(currentCompare))")
@@ -108,10 +114,10 @@ public class TestDiscordDataStructures : XCTestCase {
         }
         compare(embed1, embed2)
         let embed3 = DiscordEmbed(author: DiscordEmbed.Author(name: "Author"), image: DiscordEmbed.Image(url: dummyIconA), thumbnail: DiscordEmbed.Thumbnail(url: dummyIconA), footer: DiscordEmbed.Footer(text: "Footer", iconUrl: nil))
-        let embed4 = DiscordEmbed(embedObject: embed3.json)
+        let embed4 = DiscordEmbed(embedObject: roundTripEncode(embed3))
         currentCompare = "embed3 and embed4"
         compare(embed3, embed4)
-        let nilJSONTest = JSON.encodeJSON(embed3.json)!
+        let nilJSONTest = JSON.encodeJSON(embed3)!
         XCTAssertFalse(nilJSONTest.contains("null"), "JSON-encoded embed should not have any null fields")
     }
 

--- a/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
@@ -121,8 +121,9 @@ let permissionsTestClient = DiscordClient(token: "Testing", delegate: permission
 let permissionsTestGuildJSON = { () -> [String: Any] in
     var tmp = testGuild
     tmp["owner_id"] = String(describing: permissionsTestUsers[0].id)
-    tmp["roles"] = try! permissionsTestRoles.jsonValue()
-    return tmp
+    tmp["roles"] = permissionsTestRoles
+
+    return roundTripEncode(GenericEncodableDictionary(tmp as! [String: Encodable]))
 }()
 
 let permissionsTestGuild = DiscordGuild(guildObject: permissionsTestGuildJSON, client: permissionsTestClient)
@@ -143,8 +144,9 @@ let permissionsTestMembers = zip(permissionsTestUsers, permissionTestMemberRoles
 
 func createPermissionTestChannel(overwrites: [DiscordPermissionOverwrite]) -> DiscordGuildTextChannel {
     var channelData = testGuildTextChannel
-    channelData["permission_overwrites"] = try? overwrites.jsonValue()
+    channelData["permission_overwrites"] = overwrites
     channelData["guild_id"] = String(describing: permissionsTestGuild.id)
+    channelData = roundTripEncode(GenericEncodableDictionary(channelData as! [String: Encodable]))
     permissionsTestClient.handleChannelCreate(with: channelData)
     return permissionsTestClient.findChannel(fromId: Snowflake(channelData["id"] as! String)!) as! DiscordGuildTextChannel
 }


### PR DESCRIPTION
Now that Swift 4 is out, we have Codable!  Yaaaay!
Except that it wasn't meant for situations where you use some structs and some random dictionaries.  It really doesn't like trying to encode `[String: Any]`s or even `[String: Encodable]`s (trying to encode either with the default implementation throws a FatalError saying `fatal error: Array<Encodable> does not conform to Encodable because Encodable does not conform to itself. You must use a concrete type to encode or decode.`)
Is the new implementation hackish?  A little.  But I think it's a little less hackish than the one it's replacing.  Also, we can finally follow the Swift API Guidelines on acronyms (I'm talking about you, `Id` and `Url`) without an overly complicated snakecase function (though that's not implemented here).