### PR TITLE
Fixes leaving a channel

### DIFF
--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -380,7 +380,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
             guard let shardNum = self.guilds[engine.guildId]?.shardNumber(assuming: self.shards) else { return }
 
             let payload = DiscordGatewayPayloadData.object(["guild_id": String(describing: engine.guildId),
-                                                            "channel_id": NSNull(),
+                                                            "channel_id": nil as Bool? as Any,
                                                             "self_mute": false,
                                                             "self_deaf": false])
 

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -176,6 +176,7 @@ public class TestDiscordDataStructures : XCTestCase {
             ("testGameJSONification", testGameJSONification),
             ("testEmbedJSONification", testEmbedJSONification),
             ("testDiscordGatewayPayloadData", testDiscordGatewayPayloadData),
+            ("testDiscordGatewayPayload", testDiscordGatewayPayload),
         ]
     }
 


### PR DESCRIPTION
Issue was caused by NSNull in a dictionary, since NSNull didn't conform to Encodable