### PR TITLE
Fix everybody permission

### DIFF
--- a/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
+++ b/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
@@ -54,7 +54,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
 
     /// The voice url
     public var connectURL: String {
-        return "wss://" + voiceServerInformation.endpoint.components(separatedBy: ":")[0] + "?v=3"
+        return "wss://\(voiceServerInformation.endpoint.components(separatedBy: ":")[0])?v=3"
     }
 
     /// The connect UUID of this WebSocketable.

--- a/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordPermissions.swift
@@ -24,6 +24,8 @@ public class TestDiscordPermissions : XCTestCase {
         XCTAssertEqual(channel.permissionOverwrites.count, roleOverwrites.count, "There should be the same number of permission overwrites in this channel as we put in")
 
         XCTAssertFalse(channel.canMember(permissionsTestMembers[2], .readMessageHistory), "@everyone role should be applied to all members")
+        XCTAssertTrue(channel.canMember(permissionsTestMembers[2], .viewAuditLog), "@everyone role should be applied to all members")
+        XCTAssertFalse(channel.canMember(permissionsTestMembers[4], .viewAuditLog), "@everyone permission should be overridden by permissions for a specific role")
         XCTAssertTrue(channel.canMember(permissionsTestMembers[0], .sendMessages), "Owner should override all permissions")
         XCTAssertTrue(channel.canMember(permissionsTestMembers[1], .readMessages), "Admin role should override all permissions")
         XCTAssertTrue(channel.canMember(permissionsTestMembers[4], .addReactions), "An allow override should go over a deny of the same type")
@@ -59,8 +61,8 @@ public class TestDiscordPermissions : XCTestCase {
     }
 
     let roleOverwrites = [
-        DiscordPermissionOverwrite(id: GuildID(testGuild.get("id", as: String.self))!, type: .role, allow: [], deny: .readMessageHistory),
-        DiscordPermissionOverwrite(id: permissionsTestRoles[3].id, type: .role, allow: [], deny: [.sendMessages, .addReactions]),
+        DiscordPermissionOverwrite(id: GuildID(testGuild.get("id", as: String.self))!, type: .role, allow: .viewAuditLog, deny: .readMessageHistory),
+        DiscordPermissionOverwrite(id: permissionsTestRoles[3].id, type: .role, allow: [], deny: [.sendMessages, .addReactions, .viewAuditLog]),
         DiscordPermissionOverwrite(id: permissionsTestRoles[2].id, type: .role, allow: .addReactions, deny: []),
         DiscordPermissionOverwrite(id: permissionsTestRoles[0].id, type: .role, allow: [], deny: .readMessages),
         DiscordPermissionOverwrite(id: permissionsTestRoles[1].id, type: .role, allow: [], deny: .addReactions)


### PR DESCRIPTION
It looks like I should have checked the spec before adding the everybody permission.

The spec says that the everybody role overwrites should be applied before other roles, while the previous implementation just lumped it in with the rest of the roles.  They are now separate.

Other things changed:
- Moved the member overwrite calculation out of the giant reduce expression, making the reduce expression significantly less giant.  There's only ever one overwrite that can apply to a member, and it already has to be processed separately, so we might as well leave it out of the reduce.
- Added tests to ensure that the everybody permission continues to be applied before other roles
- Small change to a string interpolation to slightly speed up compile times (and also look more swifty)