### PR TITLE
Swift 4.1 codable nil

### DIFF
--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -384,7 +384,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
             guard let shardNum = self.guilds[engine.guildId]?.shardNumber(assuming: self.shardingInfo.totalShards) else { return }
 
             let payload = DiscordGatewayPayloadData.object(["guild_id": String(describing: engine.guildId),
-                                                            "channel_id": nil as Bool? as Any,
+                                                            "channel_id": EncodableNull(),
                                                             "self_mute": false,
                                                             "self_deaf": false])
 

--- a/Sources/SwiftDiscord/DiscordUtils.swift
+++ b/Sources/SwiftDiscord/DiscordUtils.swift
@@ -34,8 +34,7 @@ extension Dictionary where Value == Any {
 }
 
 // TODO: Remove when swift 4.1 is common
-#if swift(>=4.1)
-#else
+#if !swift(>=4.1)
     extension Optional {
         func compactMap<T>(_ transform: (Wrapped) throws -> T?) rethrows -> T? {
             return try self.flatMap(transform)
@@ -51,6 +50,13 @@ extension Dictionary where Value == Any {
 extension Dictionary where Key == String, Value == Any {
     func getSnowflake(key: String = "id") -> Snowflake {
         return Snowflake(self[key] as? String) ?? 0
+    }
+}
+
+struct EncodableNull: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encodeNil()
     }
 }
 


### PR DESCRIPTION
Change voice disconnect payload to use a special Encodable struct instead of `nil as Bool?` which breaks in Swift 4.1 because runtime conditional conformance checking of optionals isn't supported yet.