### PR TITLE
Add support for message reactions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "SSCommonCrypto",
-        "repositoryURL": "https://github.com/daltoniam/common-crypto-spm",
-        "state": {
-          "branch": null,
-          "revision": "2eb3aff0fb57f92f5722fac5d6d20bf64669ca66",
-          "version": "1.1.0"
-        }
-      },
-      {
         "package": "COPUS",
         "repositoryURL": "https://github.com/nuclearace/copus",
         "state": {
@@ -101,30 +92,12 @@
         }
       },
       {
-        "package": "Starscream",
-        "repositoryURL": "https://github.com/daltoniam/Starscream",
-        "state": {
-          "branch": null,
-          "revision": "114e5df9b6251970a069e8f1c0cbb5802759f0a9",
-          "version": "3.0.5"
-        }
-      },
-      {
         "package": "TLS",
         "repositoryURL": "https://github.com/vapor/tls.git",
         "state": {
           "branch": null,
           "revision": "02a47309249e69358aa3c28b5853897585d7a750",
           "version": "2.1.2"
-        }
-      },
-      {
-        "package": "SSCZLib",
-        "repositoryURL": "https://github.com/daltoniam/zlib-spm.git",
-        "state": {
-          "branch": null,
-          "revision": "83ac8d719a2f3aa775dbdf116a57f56fb2c49abb",
-          "version": "1.1.0"
         }
       }
     ]

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -66,7 +66,13 @@ enum JSON {
             return nil
         }
 
-        guard response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 204 else {
+        guard response.statusCode != 204 else {
+            DefaultDiscordLogger.Logger.debug("Response code 204: No content")
+            
+            return nil
+        }
+
+        guard response.statusCode == 200 || response.statusCode == 201 else {
             DefaultDiscordLogger.Logger.error("Invalid response code \(response.statusCode)", type: "JSON")
             DefaultDiscordLogger.Logger.error("Response: \(stringData)", type: "JSON")
 

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -66,7 +66,7 @@ enum JSON {
             return nil
         }
 
-        guard response.statusCode == 200 || response.statusCode == 201 else {
+        guard response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 204 else {
             DefaultDiscordLogger.Logger.error("Invalid response code \(response.statusCode)", type: "JSON")
             DefaultDiscordLogger.Logger.error("Response: \(stringData)", type: "JSON")
 

--- a/Sources/SwiftDiscord/DiscordJSON.swift
+++ b/Sources/SwiftDiscord/DiscordJSON.swift
@@ -67,7 +67,7 @@ enum JSON {
         }
 
         guard response.statusCode != 204 else {
-            DefaultDiscordLogger.Logger.debug("Response code 204: No content")
+            DefaultDiscordLogger.Logger.debug("Response code 204: No content", type: "JSON")
             
             return nil
         }

--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -51,6 +51,13 @@ public enum DiscordEndpoint : CustomStringConvertible {
     /// The channel typing endpoint.
     case typing(channel: ChannelID)
 
+    // Reactions
+    /// The endpoint for creating/deleting own reactions.
+    case reactions(channel: ChannelID, message: MessageID, emoji: String)
+    
+    /// The endpoint for another user's reactions
+    case userReactions(channel: ChannelID, message: MessageID, emoji: String, user: UserID)
+
     // Permissions
     /// The base channel permissions endpoint.
     case permissions(channel: ChannelID)
@@ -264,6 +271,11 @@ public extension DiscordEndpoint {
             return "/channels/\(channel)/messages/\(message)"
         case let .typing(channel):
             return "/channels/\(channel)/typing"
+        // Reactions
+        case let .reactions(channel, message, emoji):
+            return "/channels/\(channel)/messages/\(message)/reactions/\(emoji)/@me"
+        case let .userReactions(channel, message, emoji, user):
+            return "/channels/\(channel)/messages/\(message)/reactions/\(emoji)/\(user)"
         // Permissions
         case let .permissions(channel):
             return "/channels/\(channel)/permissions"
@@ -362,6 +374,11 @@ public extension DiscordEndpoint {
             return DiscordRateLimitKey(id: channel, urlParts: [.channels, .channelID, .messagesDelete, .messageID])
         case let .typing(channel):
             return DiscordRateLimitKey(id: channel, urlParts: [.channels, .channelID, .typing])
+        // Reactions
+        case let .reactions(channel, _, _):
+            return DiscordRateLimitKey(id: channel, urlParts: [.channels, .channelID, .messages, .messageID, .reactions, .emoji, .me])
+        case let .userReactions(channel, _, _, _):
+            return DiscordRateLimitKey(id: channel, urlParts: [.channels, .channelID, .messages, .messageID, .reactions, .emoji, .userID])
         // Permissions
         case let .permissions(channel):
             return DiscordRateLimitKey(id: channel, urlParts: [.channels, .channelID, .permissions])

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -87,7 +87,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     public func createReaction(for messageId: MessageID,
                         on channelId: ChannelID,
                         emoji: String,
-                        callback: ((DiscordMessage?, HTTPURLResponse?) -> ())?) {
+                        callback: ((DiscordMessage?, HTTPURLResponse?) -> ())? = nil) {
         let requestCallback: DiscordRequestCallback = { data, response, error in
             guard case let .object(message)? = JSON.jsonFromResponse(data: data, response: response) else {
                 callback?(nil, response)

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -97,7 +97,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             callback?(DiscordMessage(messageObject: message, client: nil), response)
         }
         
-        rateLimiter.executeRequest(endpoint: .reactions(channel: channelId, message: messageId, emoji: emoji.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
+        rateLimiter.executeRequest(endpoint: .reactions(channel: channelId, message: messageId, emoji: emoji.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? emoji),
                                    token: token,
                                    requestInfo: .put(content: nil, extraHeaders: nil),
                                    callback: requestCallback)

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -84,6 +84,26 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
+    public func createReaction(for messageId: MessageID,
+                        on channelId: ChannelID,
+                        emoji: String,
+                        callback: ((DiscordMessage?, HTTPURLResponse?) -> ())?) {
+        let requestCallback: DiscordRequestCallback = { data, response, error in
+            guard case let .object(message)? = JSON.jsonFromResponse(data: data, response: response) else {
+                callback?(nil, response)
+                return
+            }
+
+            callback?(DiscordMessage(messageObject: message, client: nil), response)
+        }
+        
+        rateLimiter.executeRequest(endpoint: .reactions(channel: channelId, message: messageId, emoji: emoji),
+                                   token: token,
+                                   requestInfo: .put(content: nil, extraHeaders: nil),
+                                   callback: requestCallback)
+    }
+
+    /// Default implementation
     public func deleteChannel(_ channelId: ChannelID,
                               reason: String? = nil,
                               callback: ((Bool, HTTPURLResponse?) -> ())? = nil) {

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -97,7 +97,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             callback?(DiscordMessage(messageObject: message, client: nil), response)
         }
         
-        rateLimiter.executeRequest(endpoint: .reactions(channel: channelId, message: messageId, emoji: emoji),
+        rateLimiter.executeRequest(endpoint: .reactions(channel: channelId, message: messageId, emoji: emoji.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
                                    token: token,
                                    requestInfo: .put(content: nil, extraHeaders: nil),
                                    callback: requestCallback)

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer.swift
@@ -70,6 +70,19 @@ public protocol DiscordEndpointConsumer {
                       callback: @escaping (DiscordInvite?, HTTPURLResponse?) -> ())
 
     ///
+    /// Creates a reaction for the specified message.
+    ///
+    /// - parameter for: The message that is to be edited's snowflake id
+    /// - parameter on: The channel that we are editing on
+    /// - parameter emoji: The emoji name
+    /// - parameter callback: An optional callback containing the edited message, if successful.
+    ///
+    func createReaction(for messageId: MessageID,
+                        on channelId: ChannelID,
+                        emoji: String,
+                        callback: ((DiscordMessage?, HTTPURLResponse?) -> ())?)
+
+    ///
     /// Deletes the specified channel.
     ///
     /// - parameter channelId: The snowflake id of the channel.

--- a/Sources/SwiftDiscord/Rest/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordRateLimiter.swift
@@ -245,6 +245,9 @@ public struct DiscordRateLimitKey : Hashable {
         static let          slack = DiscordRateLimitURLParts(rawValue: 1 << 23)
         static let         github = DiscordRateLimitURLParts(rawValue: 1 << 24)
         static let       auditLog = DiscordRateLimitURLParts(rawValue: 1 << 25)
+        static let      reactions = DiscordRateLimitURLParts(rawValue: 1 << 26)
+        static let          emoji = DiscordRateLimitURLParts(rawValue: 1 << 27)
+        static let             me = DiscordRateLimitURLParts(rawValue: 1 << 28)
 
         public init(rawValue: Int) {
             self.rawValue = rawValue


### PR DESCRIPTION
This branch adds common reaction endpoints (as specified [in the API docs](https://discordapp.com/developers/docs/resources/channel#create-reaction)) and `DiscordEndpointConsumer.createReaction`.