### PR TITLE
Migrate to WebSocketKit

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,12 @@
         }
       },
       {
-        "package": "nio-websocket-client",
-        "repositoryURL": "https://github.com/vapor/nio-websocket-client",
-        "state": {
-          "branch": null,
-          "revision": "f9a0955dff2b6a7a466cc26db2d061b682023197",
-          "version": null
-        }
-      },
-      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "32760eae40e6b7cb81d4d543bb0a9f548356d9a2",
-          "version": "2.7.1"
+          "revision": "9201908b54578aa33f1d1826a5a680aca8991843",
+          "version": "2.8.0"
         }
       },
       {
@@ -33,8 +24,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "f5dd7a60ff56f501ff7bf9be753e4b1875bfaf20",
-          "version": "2.4.0"
+          "revision": "bd235c580bd4e76beeefdefd86b86e08bd267d49",
+          "version": "2.4.2"
+        }
+      },
+      {
+        "package": "websocket-kit",
+        "repositoryURL": "https://github.com/vapor/websocket-kit",
+        "state": {
+          "branch": null,
+          "revision": "d2fbfc28cb08e7a41644a92da16a383c8f9cc6f4",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,11 +20,11 @@
 import PackageDescription
 
 var deps: [Package.Dependency] = [
-    .package(url: "https://github.com/vapor/nio-websocket-client", .revision("f9a0955dff2b6a7a466cc26db2d061b682023197")),
+    .package(url: "https://github.com/vapor/websocket-kit", .revision("d2fbfc28cb08e7a41644a92da16a383c8f9cc6f4")),
     .package(url: "https://github.com/IBM-Swift/BlueSocket", .upToNextMinor(from: "1.0.0"))
 ]
 
-var targetDeps: [Target.Dependency] = ["AsyncWebSocketClient", "COPUS", "Sodium", "Socket"]
+var targetDeps: [Target.Dependency] = ["WebSocketKit", "COPUS", "Sodium", "Socket"]
 
 let package = Package(
     name: "SwiftDiscord",

--- a/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 import NIO
-import AsyncWebSocketClient
+import WebSocketKit
 import Dispatch
 
 #if os(macOS)
@@ -99,7 +99,7 @@ open class DiscordEngine : DiscordEngineSpec {
     public var sessionId: String?
 
     /// The underlying WebSocket.
-    public var websocket: WebSocketClient.Socket?
+    public var websocket: WebSocket?
 
     /// Whether this engine is connected to the gateway.
     public internal(set) var connected = false

--- a/Sources/SwiftDiscord/Gateway/DiscordEngineSpec.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordEngineSpec.swift
@@ -118,15 +118,17 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable & DiscordRu
 
         let url = URL(string: connectURL)!
         let path = url.path.isEmpty ? "/" : url.path
-        let wsClient = WebSocketClient(eventLoopGroupProvider: .shared(runloop), configuration: .init(
-            tlsConfiguration: .clientDefault,
-            maxFrameSize: 1 << 31
-        ))
-        let future = wsClient.connect(
-                scheme: url.scheme!,
-                host: url.host!,
-                port: url.port ?? 443,
-                path: path
+
+        let future = WebSocket.connect(
+            scheme: url.scheme ?? "wss",
+            host: url.host!,
+            port: url.port ?? 443,
+            path: path,
+            configuration: .init(
+                tlsConfiguration: .clientDefault,
+                maxFrameSize: 1 << 31
+            ),
+            on: runloop
         ) { [weak self] ws in
             guard let this = self else { return }
 

--- a/Sources/SwiftDiscord/Gateway/DiscordEngineSpec.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordEngineSpec.swift
@@ -92,6 +92,8 @@ public extension DiscordWebSocketable where Self: DiscordGatewayable & DiscordRu
             guard let this = self else { return }
             
             DefaultDiscordLogger.Logger.log("Websocket closed, \(this.description)", type: "DiscordWebSocketable")
+            
+            this.handleClose(reason: nil)
         }
 
         websocket?.onClose.whenFailure { [weak self] err in

--- a/Sources/SwiftDiscord/Gateway/DiscordGateway.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordGateway.swift
@@ -100,7 +100,7 @@ public extension DiscordGatewayable where Self: DiscordWebSocketable & DiscordRu
         DefaultDiscordLogger.Logger.debug("Sending ws: \(payloadString)", type: description)
 
         runloop.execute {
-            self.websocket?.send(text: payloadString)
+            self.websocket?.send(payloadString)
         }
     }
 }

--- a/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
+++ b/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 import Dispatch
-import AsyncWebSocketClient
+import WebSocketKit
 import Socket
 import Sodium
 
@@ -86,7 +86,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
     }
 
     /// The underlying websocket.
-    public var websocket: WebSocketClient.Socket?
+    public var websocket: WebSocket?
 
     /// The voice engine's delegate.
     public private(set) weak var voiceDelegate: DiscordVoiceEngineDelegate?


### PR DESCRIPTION
## Fixes #83.

This PR migrates the WebSocket implementation to the [WebSocketKit library](https://github.com/vapor/websocket-kit) from Vapor 3.