### PR TITLE
Add support for non-guild presences

### DIFF
--- a/Sources/DiscordOpus/include/configure.h
+++ b/Sources/DiscordOpus/include/configure.h
@@ -18,7 +18,11 @@
 #ifndef configure_h
 #define configure_h
 
+#ifdef __APPLE__
+#include <opus.h>
+#else
 #include <opus/opus.h>
+#endif
 
 int configure_encoder(OpusEncoder *enc, int bitrate, int vbr);
 int configure_decoder(OpusDecoder *dec, int gain);

--- a/Sources/DiscordOpus/include/configure.h
+++ b/Sources/DiscordOpus/include/configure.h
@@ -18,7 +18,11 @@
 #ifndef configure_h
 #define configure_h
 
+#ifdef __APPLE__
+#include "/usr/local/Cellar/opus/1.3.1/include/opus/opus.h"
+#else
 #include <opus/opus.h>
+#endif
 
 int configure_encoder(OpusEncoder *enc, int bitrate, int vbr);
 int configure_decoder(OpusDecoder *dec, int gain);

--- a/Sources/DiscordOpus/include/configure.h
+++ b/Sources/DiscordOpus/include/configure.h
@@ -18,11 +18,7 @@
 #ifndef configure_h
 #define configure_h
 
-#ifdef __APPLE__
-#include "/usr/local/Cellar/opus/1.3.1/include/opus/opus.h"
-#else
 #include <opus/opus.h>
-#endif
 
 int configure_encoder(OpusEncoder *enc, int bitrate, int vbr);
 int configure_decoder(OpusDecoder *dec, int gain);

--- a/Sources/DiscordOpus/include/configure.h
+++ b/Sources/DiscordOpus/include/configure.h
@@ -18,11 +18,7 @@
 #ifndef configure_h
 #define configure_h
 
-#ifdef __APPLE__
-#include <opus.h>
-#else
 #include <opus/opus.h>
-#endif
 
 int configure_encoder(OpusEncoder *enc, int bitrate, int vbr);
 int configure_decoder(OpusDecoder *dec, int gain);

--- a/Sources/SwiftDiscord/User/DiscordPresence.swift
+++ b/Sources/SwiftDiscord/User/DiscordPresence.swift
@@ -327,3 +327,14 @@ public struct DiscordPresenceUpdate : Encodable {
         case afk
     }
 }
+
+func presencesFromArray(_ presences: [[String: Any]], client: DiscordClient) -> [UserID: DiscordPresence] {
+    var presenceDict = [UserID: DiscordPresence]()
+    
+    for presence in presences {
+        let newPresence = DiscordPresence(presenceObject: presence, guildId: GuildID(0))
+        presenceDict[newPresence.user.id] = newPresence
+    }
+    
+    return presenceDict
+}

--- a/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
+++ b/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
@@ -232,7 +232,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
 
         defer { encrypted.deallocate() }
 
-        let success = crypto_secretbox_easy(encrypted, &buf, UInt64(buf.count), &nonce, &secret!)
+        let success = crypto_secretbox_easy(encrypted, &buf, UInt64(buf.count), &nonce, secret!)
 
         guard success != -1 else { throw EngineError.encryptionError }
 
@@ -252,7 +252,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
 
         defer { unencrypted.deallocate() }
 
-        let success = crypto_secretbox_open_easy(unencrypted, voiceData, UInt64(data.count - 12), &nonce, &secret!)
+        let success = crypto_secretbox_open_easy(unencrypted, voiceData, UInt64(data.count - 12), &nonce, secret!)
 
         guard success != -1 else { throw EngineError.decryptionError }
 


### PR DESCRIPTION
The presences of users that the current user has DMs with and is friends with are sent as part of the initial `READY` frame but are currently ignored. This adds support for these presences.