### PR TITLE
Fix a typo in EndpointRequest

### DIFF
--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -170,7 +170,7 @@ public extension DiscordEndpoint {
         /// A POST request.
         case post(content: HTTPContent?, extraHeaders: [DiscordHeader: String]?)
 
-        /// A POST request.
+        /// A PUT request.
         case put(content: HTTPContent?, extraHeaders: [DiscordHeader: String]?)
 
         /// A PATCH request.


### PR DESCRIPTION
Fix a typo in the doc comment of `EndpointRequest.put`.