### PR TITLE
Update URLs to discord.com

### DIFF
--- a/Sources/SwiftDiscord/Audit/DiscordAuditLogEntry.swift
+++ b/Sources/SwiftDiscord/Audit/DiscordAuditLogEntry.swift
@@ -32,7 +32,7 @@ public struct DiscordAuditLogEntry {
 
     // TODO An actual struct for this?
     /// Optional audit entry information for certain action types.
-    /// [Structure](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info)
+    /// [Structure](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info)
     public let options: [String: Any]
 
     /// The reason for this entry.

--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -261,7 +261,7 @@ public extension DiscordEndpoint {
     var description: String {
         switch self {
         case .baseURL:
-            return "https://discordapp.com/api/v6"
+            return "https://discord.com/api/v6"
 
         /* Channels */
         case let .channel(id):

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointGateway.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointGateway.swift
@@ -32,7 +32,7 @@ struct DiscordEndpointGateway {
         #if os(Linux)
         return "wss://gateway.discord.gg"
         #else
-        var request = URLRequest(url: URL(string: "https://discordapp.com/api/gateway")!)
+        var request = URLRequest(url: URL(string: "https://discord.com/api/gateway")!)
 
         request.httpMethod = "GET"
 

--- a/Sources/SwiftDiscord/Rest/DiscordOAuth.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordOAuth.swift
@@ -20,7 +20,7 @@ import Foundation
 /// Represents the Discord OAuth endpoint and the different scopes Disocrd has.
 public enum DiscordOAuthEndpoint : String {
     /// The base OAuth endpoint.
-    case baseURL = "https://discordapp.com/api/oauth2/authorize"
+    case baseURL = "https://discord.com/api/oauth2/authorize"
 
     /// The bot scope.
     case bot

--- a/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
+++ b/Sources/SwiftDiscord/Voice/DiscordVoiceEngine.swift
@@ -287,7 +287,7 @@ public final class DiscordVoiceEngine : DiscordVoiceEngineSpec {
         return (ipString, port)
     }
 
-    // https://discordapp.com/developers/docs/topics/voice-connections#ip-discovery
+    // https://discord.com/developers/docs/topics/voice-connections#ip-discovery
     private func findIP() {
         udpQueueWrite.async {
             guard let udpSocket = self.udpSocket else { return }

--- a/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordDataStructures.swift
@@ -68,7 +68,7 @@ public class TestDiscordDataStructures : XCTestCase {
     func testEmbedJSONification() {
         let dummyIconA = URL(string: "https://cdn.discordapp.com/embed/avatars/0.png")!
         let dummyIconB = URL(string: "https://cdn.discordapp.com/embed/avatars/1.png")!
-        let dummyURL = URL(string: "https://discordapp.com")!
+        let dummyURL = URL(string: "https://discord.com")!
 
         let embed1 = DiscordEmbed(
             title: "Title",


### PR DESCRIPTION
Discord is currently migrating their non-CDN-domains from `discordapp.com` to `discord.com` and will be dropping API support for `discordapp.com` on November 7, 2020.