### PR TITLE
Add support for creation and deletion of emojis

### DIFF
--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -155,6 +155,9 @@ public enum DiscordEndpoint : CustomStringConvertible {
     /* Emoji */
     // The guild's emojis endpoint.
     case guildEmojis(guild: GuildID)
+
+    // The guild's emoji endpoint
+    case guildEmoji(guild: GuildID, emoji: EmojiID)
     /* End Emoji */
 
     var combined: String {
@@ -363,6 +366,8 @@ public extension DiscordEndpoint {
         /* Emoji */
         case let .guildEmojis(guild):
             return "/guilds/\(guild)/emojis"
+        case let .guildEmoji(guild, emoji):
+            return "/guilds/\(guild)/emojis/\(emoji)"
         /* End Emoji */
         }
     }
@@ -470,7 +475,9 @@ public extension DiscordEndpoint {
 
         /* Emoji */
         case let .guildEmojis(guild):
-            return DiscordRateLimitKey(id: guild, urlParts: [.guilds, .guildID, .webhooks])
+            return DiscordRateLimitKey(id: guild, urlParts: [.guilds, .guildID, .emojis])
+        case let .guildEmoji(guild, _):
+            return DiscordRateLimitKey(id: guild, urlParts: [.guilds, .guildID, .emojis, .emojiID])
         /* End Emoji */
         }
     }

--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -152,6 +152,11 @@ public enum DiscordEndpoint : CustomStringConvertible {
     case webhookGithub(id: WebhookID, token: String)
     /* End Webhooks */
 
+    /* Emoji */
+    // The guild's emojis endpoint.
+    case guildEmojis(guild: GuildID)
+    /* End Emoji */
+
     var combined: String {
         return DiscordEndpoint.baseURL.description + description
     }
@@ -354,6 +359,11 @@ public extension DiscordEndpoint {
         case let .webhookGithub(id, token):
             return "/webhooks/\(id)/\(token)/github"
         /* End Webhooks */
+
+        /* Emoji */
+        case let .guildEmojis(guild):
+            return "/guilds/\(guild)/emojis"
+        /* End Emoji */
         }
     }
 
@@ -457,6 +467,11 @@ public extension DiscordEndpoint {
         case .webhookGithub:
             return DiscordRateLimitKey(urlParts: [.webhooks, .webhookID, .webhookToken, .github])
         /* End Webhooks */
+
+        /* Emoji */
+        case let .guildEmojis(guild):
+            return DiscordRateLimitKey(id: guild, urlParts: [.guilds, .guildID, .webhooks])
+        /* End Emoji */
         }
     }
 

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
@@ -1,0 +1,29 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Logging
+
+fileprivate let logger = Logger(label: "DiscordEndpointEmoji")
+
+public extension DiscordEndpointConsumer where Self: DiscordUserActor {
+    // Default implementation
+    func createGuildEmoji(on guildId: GuildID,
+                                name: String,
+                                image: String,
+                                roles: [RoleID],
+                                callback: ((Bool, HTTPURLResponse?) -> ())?) {
+        var createJSON = [String: Encodable]()
+
+        createJSON["name"] = name
+        createJSON["image"] = image
+        createJSON["roles"] = roles.map { String($0.rawValue) }
+
+        guard let contentData = JSON.encodeJSONData(GenericEncodableDictionary(createJSON)) else { return }
+
+        rateLimiter.executeRequest(endpoint: .guildEmojis(guild: guildId),
+                                   token: token,
+                                   requestInfo: .post(content: .json(contentData), extraHeaders: nil),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204, response) })
+    }
+}

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
@@ -45,4 +45,23 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                    requestInfo: .get(params: nil, extraHeaders: nil),
                                    callback: requestCallback)
     }
+
+    // Default implementation
+    func getGuildEmoji(on guildId: GuildID,
+                                for emojiId: EmojiID,
+                                callback: @escaping (DiscordEmoji?, HTTPURLResponse?) -> ()) {
+        let requestCallback: DiscordRequestCallback = { data, response, error in
+            guard case let .object(emoji)? = JSON.jsonFromResponse(data: data, response: response) else {
+                callback(nil, response)
+                return
+            }
+
+            callback(DiscordEmoji(emojiObject: emoji), response)
+        }
+
+        rateLimiter.executeRequest(endpoint: .guildEmoji(guild: guildId, emoji: emojiId),
+                                   token: token,
+                                   requestInfo: .get(params: nil, extraHeaders: nil),
+                                   callback: requestCallback)
+    }
 }

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
@@ -12,7 +12,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                 name: String,
                                 image: String,
                                 roles: [RoleID],
-                                callback: ((Bool, HTTPURLResponse?) -> ())?) {
+                                callback: ((Bool, HTTPURLResponse?) -> ())? = nil) {
         var createJSON = [String: Encodable]()
 
         createJSON["name"] = name

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Emoji.swift
@@ -64,4 +64,14 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
                                    requestInfo: .get(params: nil, extraHeaders: nil),
                                    callback: requestCallback)
     }
+
+    // Default implementation
+    func deleteGuildEmoji(on guildId: GuildID,
+                                    for emojiId: EmojiID,
+                                    callback: ((Bool, HTTPURLResponse?) -> ())? = nil) {
+        rateLimiter.executeRequest(endpoint: .guildEmoji(guild: guildId, emoji: emojiId),
+                                   token: token,
+                                   requestInfo: .delete(content: nil, extraHeaders: nil),
+                                   callback: { _, response, _ in callback?(response?.statusCode == 204, response) })
+    }
 }

--- a/Sources/SwiftDiscord/Rest/DiscordRateLimiter.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordRateLimiter.swift
@@ -254,7 +254,9 @@ public struct DiscordRateLimitKey : Hashable {
         static let       auditLog = DiscordRateLimitURLParts(rawValue: 1 << 25)
         static let      reactions = DiscordRateLimitURLParts(rawValue: 1 << 26)
         static let          emoji = DiscordRateLimitURLParts(rawValue: 1 << 27)
-        static let             me = DiscordRateLimitURLParts(rawValue: 1 << 28)
+        static let         emojis = DiscordRateLimitURLParts(rawValue: 1 << 28)
+        static let        emojiID = DiscordRateLimitURLParts(rawValue: 1 << 29)
+        static let             me = DiscordRateLimitURLParts(rawValue: 1 << 30)
 
         public init(rawValue: Int) {
             self.rawValue = rawValue


### PR DESCRIPTION
Extend the `DiscordEndpointConsumer` to support emoji-related endpoints, specifically for creation and deletion of emojis on a guild.