### PR TITLE
Implement reaction deletion endpoints

### DIFF
--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Channels.swift
@@ -110,6 +110,37 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
     }
 
     /// Default implementation
+    func deleteOwnReaction(for messageId: MessageID,
+                        on channelId: ChannelID,
+                        emoji: String,
+                        callback: ((Bool, HTTPURLResponse?) -> ())?) {
+        let requestCallback: DiscordRequestCallback = { data, response, error in
+            callback?(response?.statusCode == 204, response)
+        }
+        
+        rateLimiter.executeRequest(endpoint: .reactions(channel: channelId, message: messageId, emoji: emoji.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? emoji),
+                                   token: token,
+                                   requestInfo: .delete(content: nil, extraHeaders: nil),
+                                   callback: requestCallback)
+    }
+
+    /// Default implementation
+    func deleteUserReaction(for messageId: MessageID,
+                        on channelId: ChannelID,
+                        emoji: String,
+                        by userId: UserID,
+                        callback: ((Bool, HTTPURLResponse?) -> ())?) {
+        let requestCallback: DiscordRequestCallback = { data, response, error in
+            callback?(response?.statusCode == 204, response)
+        }
+        
+        rateLimiter.executeRequest(endpoint: .userReactions(channel: channelId, message: messageId, emoji: emoji.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? emoji, user: userId),
+                                   token: token,
+                                   requestInfo: .delete(content: nil, extraHeaders: nil),
+                                   callback: requestCallback)
+    }
+
+    /// Default implementation
     func deleteChannel(_ channelId: ChannelID,
                               reason: String? = nil,
                               callback: ((Bool, HTTPURLResponse?) -> ())? = nil) {

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer.swift
@@ -86,6 +86,34 @@ public protocol DiscordEndpointConsumer {
                         callback: ((DiscordMessage?, HTTPURLResponse?) -> ())?)
 
     ///
+    /// Deletes a reaction the current user has made for the specified message.
+    ///
+    /// - parameter for: The message that is to be edited's snowflake id
+    /// - parameter on: The channel that we are editing on
+    /// - parameter emoji: The emoji name
+    /// - parameter callback: An optional callback containing the edited message, if successful.
+    ///
+    func deleteOwnReaction(for messageId: MessageID,
+                        on channelId: ChannelID,
+                        emoji: String,
+                        callback: ((Bool, HTTPURLResponse?) -> ())?)
+    
+    ///
+    /// Deletes a reaction another user has made for the specified message.
+    ///
+    /// - parameter for: The message that is to be edited's snowflake id
+    /// - parameter on: The channel that we are editing on
+    /// - parameter emoji: The emoji name
+    /// - parameter by: The snowflake id of the user
+    /// - parameter callback: An optional callback containing the edited message, if successful.
+    ///
+    func deleteUserReaction(for messageId: MessageID,
+                        on channelId: ChannelID,
+                        emoji: String,
+                        by userId: UserID,
+                        callback: ((Bool, HTTPURLResponse?) -> ())?)
+
+    ///
     /// Deletes the specified channel.
     ///
     /// - parameter channelId: The snowflake id of the channel.


### PR DESCRIPTION
Implement `DiscordEndpointConsumer.deleteOwnReaction` and `.deleteUserReaction` as defined by the [API docs](https://discord.com/developers/docs/resources/channel#delete-own-reaction).