### PR TITLE
Migrate to API and Gateway v8

### DIFF
--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -877,6 +877,13 @@ public struct DiscordAllowedMentions : Encodable {
     public let users: [UserID]
     /// For replies, whether to mention the author of the message being replied to (default: false)
     public let repliedUser: Bool
+
+    public init(parse: DiscordAllowedMentionType = .everyone, roles: [RoleID] = [], users: [UserID] = [], repliedUser: Bool = false) {
+        self.parse = parse
+        self.roles = roles
+        self.users = users
+        self.repliedUser = repliedUser
+    }
 }
 
 /// A reference to a message, e.g. used in outgoing replies.
@@ -890,4 +897,10 @@ public struct DiscordMessageReference : Encodable {
     public let messageId: MessageID?
     public let channelId: ChannelID?
     public let guildId: GuildID?
+
+    public init(messageId: MessageID? = nil, channelId: ChannelID? = nil, guildId: GuildID? = nil) {
+        self.messageId = messageId
+        self.channelId = channelId
+        self.guildId = guildId
+    }
 }

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -231,28 +231,52 @@ public extension DiscordMessage {
     /// Type of message
     enum MessageType : Int {
         /// Default.
-        case `default`
+        case `default` = 0
 
         /// Recipient Add.
-        case recipientAdd
+        case recipientAdd = 1
 
         /// Recipient Remove.
-        case recipientRemove
+        case recipientRemove = 2
 
         /// Call.
-        case call
+        case call = 3
 
         /// Channel name change.
-        case channelNameChange
+        case channelNameChange = 4
 
         /// Channel icon change.
-        case channelIconChange
+        case channelIconChange = 5
 
         /// Channel pinned message.
-        case channelPinnedMessage
+        case channelPinnedMessage = 6
 
         /// Guild member join.
-        case guildMemberJoin
+        case guildMemberJoin = 7
+
+        /// User premium guild subscription.
+        case userPremiumGuildSubscription = 8
+
+        /// User premium guild subscription tier 1.
+        case userPremiumGuildSubscriptionTier1 = 9
+
+        /// User premium guild subscription tier 2.
+        case userPremiumGuildSubscriptionTier2 = 10
+
+        /// User premium guild subscription tier 3.
+        case userPremiumGuildSubscriptionTier3 = 11
+
+        /// Channel follow add.
+        case channelFollowAdd = 12
+
+        /// Guild discovery disqualified.
+        case guildDiscoveryDisqualified = 14
+
+        /// Guild discovery requalified.
+        case guildDiscoveryRequalified = 15
+
+        /// Message reply.
+        case reply = 19
     }
 
     /// Represents an action that be taken on a message.

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -97,6 +97,9 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     /// The reactions a message has.
     public let reactions: [DiscordReaction]
 
+    /// The stickers a message has.
+    public let stickers: [DiscordMessageSticker]
+
     /// The timestamp of this message.
     public let timestamp: Date
 
@@ -151,6 +154,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         nonce = messageObject.getSnowflake(key: "nonce")
         pinned = messageObject.get("pinned", or: false)
         reactions = DiscordReaction.reactionsFromArray(messageObject.get("reactions", or: []))
+        stickers = DiscordMessageSticker.stickersFromArray(messageObject.get("sticker", or: []))
         tts = messageObject.get("tts", or: false)
         editedTimestamp = DiscordDateFormatter.format(messageObject.get("edited_timestamp", or: "")) ?? Date()
         timestamp = DiscordDateFormatter.format(messageObject.get("timestamp", or: "")) ?? Date()
@@ -194,6 +198,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         self.nonce = 0
         self.pinned = false
         self.reactions = []
+        self.stickers = []
         self.editedTimestamp = Date()
         self.timestamp = Date()
         self.type = .default
@@ -902,5 +907,45 @@ public struct DiscordMessageReference : Encodable {
         self.messageId = messageId
         self.channelId = channelId
         self.guildId = guildId
+    }
+}
+
+public enum DiscordMessageStickerFormatType: Int {
+    case png = 1
+    case apng = 2
+    case lottie = 3
+}
+
+public struct DiscordMessageSticker {
+    /// ID of the sticker
+    public let id: Snowflake
+    /// ID of the sticker pack
+    public let packId: Snowflake
+    /// Name of the sticker
+    public let name: String
+    /// Description of the sticker
+    public let description: String
+    /// List of tags for the sticker
+    public let tags: [String]
+    /// Sticker asset hash
+    public let asset: String?
+    /// Sticker preview asset hash
+    public let previewAsset: String?
+    /// Type of sticker format
+    public let formatType: DiscordMessageStickerFormatType?
+
+    init(stickerObject: [String: Any]) {
+        id = stickerObject.getSnowflake(key: "id")
+        packId = stickerObject.getSnowflake(key: "pack_id")
+        name = stickerObject.get("name", or: "")
+        description = stickerObject.get("description", or: "")
+        tags = stickerObject.get("tags", or: "").split(separator: ",").map(String.init)
+        asset = stickerObject.get("asset", as: String.self)
+        previewAsset = stickerObject.get("preview_asset", as: String.self)
+        formatType = stickerObject.get("format_type", as: Int.self).flatMap(DiscordMessageStickerFormatType.init(rawValue:))
+    }
+
+    static func stickersFromArray(_ stickerArray: [[String: Any]]) -> [DiscordMessageSticker] {
+        return stickerArray.map(DiscordMessageSticker.init)
     }
 }

--- a/Sources/SwiftDiscord/DiscordClient.swift
+++ b/Sources/SwiftDiscord/DiscordClient.swift
@@ -69,6 +69,9 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     /// If we should only represent a single shard, this is the shard information.
     public var shardingInfo = try! DiscordShardInformation(shardRange: 0..<1, totalShards: 1)
 
+    /// The gateway intents.
+    public var intents = DiscordGatewayIntent.unprivilegedIntents
+
     /// Whether large guilds should have their users fetched as soon as they are created.
     public var fillLargeGuilds = false
 
@@ -124,6 +127,8 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
                 self.shardingInfo = shardingInfo
             case let .voiceConfiguration(config):
                 self.voiceManager.engineConfiguration = config
+            case let .intents(intents):
+                self.intents = intents
             case .discardPresences:
                 discardPresences = true
             case .fillLargeGuilds:
@@ -151,7 +156,7 @@ open class DiscordClient : DiscordClientSpec, DiscordDispatchEventHandler, Disco
     open func connect() {
         logger.info("Connecting")
 
-        shardManager.manuallyShatter(withInfo: shardingInfo)
+        shardManager.manuallyShatter(withInfo: shardingInfo, intents: intents)
 
         shardManager.connect()
     }

--- a/Sources/SwiftDiscord/DiscordClientOption.swift
+++ b/Sources/SwiftDiscord/DiscordClientOption.swift
@@ -39,6 +39,10 @@ public enum DiscordClientOption : CustomStringConvertible, Equatable {
     /// However this means that invsible users will also be pruned.
     case pruneUsers
 
+    /// The gateway intents. By default, only the unprivileged intents are used, i.e. you won't
+    /// get guild member and presence events, unless you specify these here (e.g. by using .allIntents).
+    case intents(DiscordGatewayIntent)
+
     /// A DiscordRateLimiter for this client. All REST calls will be put through this limiter.
     case rateLimiter(DiscordRateLimiterSpec)
 
@@ -60,6 +64,7 @@ public enum DiscordClientOption : CustomStringConvertible, Equatable {
         case .rateLimiter:          return "rateLimiter"
         case .shardingInfo:         return "shardingInfo"
         case .pruneUsers:           return "pruneUsers"
+        case .intents:              return "intents"
         case .voiceConfiguration:   return "voiceConfiguration"
         }
     }

--- a/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
@@ -39,7 +39,7 @@ open class DiscordEngine : DiscordEngineSpec {
 
     /// The url for the gateway.
     open var connectURL: String {
-        return DiscordEndpointGateway.gatewayURL + "/?v=6&encoding=json"
+        return DiscordEndpointGateway.gatewayURL + "/?v=8&encoding=json"
     }
 
     /// The type of DiscordEngineSpec. Used to correctly fire events.

--- a/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
@@ -52,6 +52,7 @@ open class DiscordEngine : DiscordEngineSpec {
     open var handshakeObject: [String: Any] {
         var identify: [String: Any] = [
             "token": delegate!.token.token,
+            "intents": intents.rawValue,
             "properties": [
                 "$os": os,
                 "$browser": "SwiftDiscord",
@@ -91,6 +92,9 @@ open class DiscordEngine : DiscordEngineSpec {
 
     /// The shard number of this engine.
     public let shardNum: Int
+
+    /// The intents used when connecting to the gateway.
+    public let intents: DiscordGatewayIntent
 
     /// The queue that WebSockets use to parse things.
     public let parseQueue = DispatchQueue(label: "discordEngine.parseQueue")
@@ -136,10 +140,11 @@ open class DiscordEngine : DiscordEngineSpec {
     ///
     /// - parameter delegate: The DiscordClientSpec this engine should be associated with.
     ///
-    public required init(delegate: DiscordShardDelegate, shardNum: Int = 0, numShards: Int = 1, onLoop: EventLoop) {
+    public required init(delegate: DiscordShardDelegate, shardNum: Int = 0, numShards: Int = 1, intents: DiscordGatewayIntent = .unprivilegedIntents, onLoop: EventLoop) {
         self.delegate = delegate
         self.shardNum = shardNum
         self.numShards = numShards
+        self.intents = intents
         self.runloop = onLoop
     }
 

--- a/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordEngine.swift
@@ -140,7 +140,7 @@ open class DiscordEngine : DiscordEngineSpec {
     ///
     /// - parameter delegate: The DiscordClientSpec this engine should be associated with.
     ///
-    public required init(delegate: DiscordShardDelegate, shardNum: Int = 0, numShards: Int = 1, intents: DiscordGatewayIntent = .unprivilegedIntents, onLoop: EventLoop) {
+    public required init(delegate: DiscordShardDelegate, shardNum: Int = 0, numShards: Int = 1, intents: DiscordGatewayIntent, onLoop: EventLoop) {
         self.delegate = delegate
         self.shardNum = shardNum
         self.numShards = numShards

--- a/Sources/SwiftDiscord/Gateway/DiscordGatewayIntent.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordGatewayIntent.swift
@@ -1,0 +1,42 @@
+/// An intent defines the events the gateway should
+/// subscribe to.
+///
+/// See https://discord.com/developers/docs/topics/gateway#gateway-intents
+public struct DiscordGatewayIntent : OptionSet {
+    public let rawValue: Int
+
+    /// Creation, updates and deletions of guilds, roles and channels.
+    public static let guilds = DiscordGatewayIntent(rawValue: 1 << 0)
+    /// Guild member update events. This is a privileged intent.
+    public static let guildMembers = DiscordGatewayIntent(rawValue: 1 << 1)
+    /// Guild ban and unban events.
+    public static let guildBans = DiscordGatewayIntent(rawValue: 1 << 2)
+    /// Guild emoji update events.
+    public static let guildEmojis = DiscordGatewayIntent(rawValue: 1 << 3)
+    /// Guild integration update events.
+    public static let guildIntegrations = DiscordGatewayIntent(rawValue: 1 << 4)
+    /// Guild webhook update events.
+    public static let guildWebhooks = DiscordGatewayIntent(rawValue: 1 << 5)
+    /// Guild invite events.
+    public static let guildInvites = DiscordGatewayIntent(rawValue: 1 << 6)
+    /// Guild voice state update events.
+    public static let guildVoiceStates = DiscordGatewayIntent(rawValue: 1 << 7)
+    /// Guild presence update events. This is a privileged intent.
+    public static let guildPresences = DiscordGatewayIntent(rawValue: 1 << 8)
+    /// Guild message creations, updates and deletions.
+    public static let guildMessages = DiscordGatewayIntent(rawValue: 1 << 9)
+    /// Guild message reaction creations, updates and deletions.
+    public static let guildMessageReactions = DiscordGatewayIntent(rawValue: 1 << 10)
+    /// Guild typing indicators.
+    public static let guildMessageTyping = DiscordGatewayIntent(rawValue: 1 << 11)
+    /// Direct message creations, updates and deletions.
+    public static let directMessages = DiscordGatewayIntent(rawValue: 1 << 12)
+    /// Direct message reaction creations, updates and deletions.
+    public static let directMessageReactions = DiscordGatewayIntent(rawValue: 1 << 13)
+    /// Direct message typing indicators.
+    public static let directMessageTyping = DiscordGatewayIntent(rawValue: 1 << 14)
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}

--- a/Sources/SwiftDiscord/Gateway/DiscordGatewayIntent.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordGatewayIntent.swift
@@ -36,6 +36,35 @@ public struct DiscordGatewayIntent : OptionSet {
     /// Direct message typing indicators.
     public static let directMessageTyping = DiscordGatewayIntent(rawValue: 1 << 14)
 
+    /// The privileged intents (which may require enabling in the Discord developer console).
+    public static let privilegedIntents: DiscordGatewayIntent = [
+        .guildMembers,
+        .guildPresences
+    ]
+
+    /// The unprivileged intents. Use these if you don't need the privileged intents.
+    public static let unprivilegedIntents: DiscordGatewayIntent = [
+        .guilds,
+        .guildBans,
+        .guildEmojis,
+        .guildIntegrations,
+        .guildWebhooks,
+        .guildInvites,
+        .guildVoiceStates,
+        .guildMessages,
+        .guildMessageReactions,
+        .guildMessageTyping,
+        .directMessages,
+        .directMessageReactions,
+        .directMessageTyping
+    ]
+
+    /// All intents.
+    public static let allIntents: DiscordGatewayIntent = [
+        .privilegedIntents,
+        .unprivilegedIntents
+    ]
+
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }

--- a/Sources/SwiftDiscord/Gateway/DiscordSharding.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordSharding.swift
@@ -231,8 +231,8 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
     /// - returns: A new `DiscordShard`
     ///
     open func createShardWithDelegate(_ delegate: DiscordShardManagerDelegate, withShardNum shardNum: Int,
-                                      totalShards: Int, onloop: EventLoop) -> DiscordShard {
-        return DiscordEngine(delegate: self, shardNum: shardNum, numShards: totalShards, onLoop: onloop)
+                                      totalShards: Int, intents: DiscordGatewayIntent, onloop: EventLoop) -> DiscordShard {
+        return DiscordEngine(delegate: self, shardNum: shardNum, numShards: totalShards, intents: intents, onLoop: onloop)
     }
 
     ///
@@ -258,7 +258,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
     ///
     /// - parameter withInfo: The information about this single shard.
     ///
-    open func manuallyShatter(withInfo info: DiscordShardInformation) {
+    open func manuallyShatter(withInfo info: DiscordShardInformation, intents: DiscordGatewayIntent) {
         guard let delegate = self.delegate else { return }
 
         logger.debug("(verbose) Handling shard range \(info.shardRange)")
@@ -270,6 +270,7 @@ open class DiscordShardManager : DiscordShardDelegate, Lockable {
                 shards.append(createShardWithDelegate(delegate,
                                                       withShardNum: shardNum,
                                                       totalShards: info.totalShards,
+                                                      intents: intents,
                                                       onloop: delegate.runloops.next()))
             }
         }

--- a/Sources/SwiftDiscord/Gateway/DiscordSharding.swift
+++ b/Sources/SwiftDiscord/Gateway/DiscordSharding.swift
@@ -91,7 +91,7 @@ public protocol DiscordShard : DiscordWebSocketable, DiscordGatewayable, Discord
     ///
     /// - parameter client: The client this engine should be associated with.
     ///
-    init(delegate: DiscordShardDelegate, shardNum: Int, numShards: Int, onLoop: EventLoop)
+    init(delegate: DiscordShardDelegate, shardNum: Int, numShards: Int, intents: DiscordGatewayIntent, onLoop: EventLoop)
 }
 
 /// Declares that a type will be a shard's delegate.

--- a/Sources/SwiftDiscord/Guild/DiscordGuild.swift
+++ b/Sources/SwiftDiscord/Guild/DiscordGuild.swift
@@ -83,7 +83,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
     public private(set) var defaultMessageNotifications: Int
 
     /// The snowflake id of the embed channel for this guild.
-    public private(set) var embedChannelId: ChannelID
+    public private(set) var widgetChannelId: ChannelID
 
     /// Whether this guild has embed enabled.
     public private(set) var widgetEnabled: Bool
@@ -114,7 +114,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
         channels = guildChannels(fromArray: guildObject.get("channels", or: JSONArray()), guildID: id, client: client)
         defaultMessageNotifications = guildObject.get("default_message_notifications", or: -1)
         widgetEnabled = guildObject.get("widget_enabled", or: false)
-        embedChannelId = guildObject.getSnowflake(key: "embed_channel_id")
+        widgetChannelId = guildObject.getSnowflake(key: "widget_channel_id")
         emojis = DiscordEmoji.emojisFromArray(guildObject.get("emojis", or: JSONArray()))
         features = guildObject.get("features", or: Array<Any>())
         icon = guildObject.get("icon", or: "")
@@ -313,8 +313,8 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
             self.defaultMessageNotifications = defaultMessageNotifications
         }
 
-        if let embedChannelId = Snowflake(newGuild["embed_channel_id"] as? String) {
-            self.embedChannelId = embedChannelId
+        if let widgetChannelId = Snowflake(newGuild["widget_channel_id"] as? String) {
+            self.widgetChannelId = widgetChannelId
         }
 
         if let widgetEnabled = newGuild["widget_enabled"] as? Bool {

--- a/Sources/SwiftDiscord/Guild/DiscordGuild.swift
+++ b/Sources/SwiftDiscord/Guild/DiscordGuild.swift
@@ -86,7 +86,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
     public private(set) var embedChannelId: ChannelID
 
     /// Whether this guild has embed enabled.
-    public private(set) var embedEnabled: Bool
+    public private(set) var widgetEnabled: Bool
 
     /// The base64 encoded icon image for this guild.
     public private(set) var icon: String
@@ -113,7 +113,7 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
         id = guildObject.getSnowflake()
         channels = guildChannels(fromArray: guildObject.get("channels", or: JSONArray()), guildID: id, client: client)
         defaultMessageNotifications = guildObject.get("default_message_notifications", or: -1)
-        embedEnabled = guildObject.get("embed_enabled", or: false)
+        widgetEnabled = guildObject.get("widget_enabled", or: false)
         embedChannelId = guildObject.getSnowflake(key: "embed_channel_id")
         emojis = DiscordEmoji.emojisFromArray(guildObject.get("emojis", or: JSONArray()))
         features = guildObject.get("features", or: Array<Any>())
@@ -317,8 +317,8 @@ public final class DiscordGuild : DiscordClientHolder, CustomStringConvertible {
             self.embedChannelId = embedChannelId
         }
 
-        if let embedEnabled = newGuild["embed_enabled"] as? Bool {
-            self.embedEnabled = embedEnabled
+        if let widgetEnabled = newGuild["widget_enabled"] as? Bool {
+            self.widgetEnabled = widgetEnabled
         }
 
         if let icon = newGuild["icon"] as? String {

--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -582,7 +582,7 @@ public extension DiscordEndpoint {
             case name(String)
 
             /// The permissions this role has.
-            case permissions(Int)
+            case permissions(DiscordPermission)
         }
 
         /// Options for getting messages

--- a/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpoint.swift
@@ -274,7 +274,7 @@ public extension DiscordEndpoint {
     var description: String {
         switch self {
         case .baseURL:
-            return "https://discord.com/api/v6"
+            return "https://discord.com/api/v8"
 
         /* Channels */
         case let .channel(id):

--- a/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Guilds.swift
+++ b/Sources/SwiftDiscord/Rest/DiscordEndpointConsumer+Guilds.swift
@@ -110,7 +110,7 @@ public extension DiscordEndpointConsumer where Self: DiscordUserActor {
             case let .name(name):
                 roleData["name"] = name
             case let .permissions(permissions):
-                roleData["permissions"] = permissions
+                roleData["permissions"] = permissions.rawValue.description
             }
         }
 

--- a/Sources/SwiftDiscord/User/DiscordPermission.swift
+++ b/Sources/SwiftDiscord/User/DiscordPermission.swift
@@ -93,6 +93,11 @@ public struct DiscordPermission : OptionSet, Encodable {
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue.description)
+    }
 }
 
 /// Represents a permission overwrite type for a channel.

--- a/Sources/SwiftDiscord/User/DiscordPermission.swift
+++ b/Sources/SwiftDiscord/User/DiscordPermission.swift
@@ -17,6 +17,9 @@
 
 /// Represents a Discord Permission. Calculating Permissions involves bitwise operations.
 public struct DiscordPermission : OptionSet, Encodable {
+    // TODO: Migrate to BigInt or similar since permission are string-serialized
+    //       and may have arbitrary size as of v8
+
     public let rawValue: Int
 
     /// This user can create invites.
@@ -138,8 +141,8 @@ public struct DiscordPermissionOverwrite : Encodable {
     init(permissionOverwriteObject: [String: Any]) {
         id = permissionOverwriteObject.getSnowflake()
         type = DiscordPermissionOverwriteType(rawValue: permissionOverwriteObject.get("type", or: "")) ?? .role
-        allow = DiscordPermission(rawValue: permissionOverwriteObject.get("allow", or: 0))
-        deny = DiscordPermission(rawValue: permissionOverwriteObject.get("deny", or: 0))
+        allow = DiscordPermission(rawValue: Int(permissionOverwriteObject.get("allow", or: "0")) ?? 0)
+        deny = DiscordPermission(rawValue: Int(permissionOverwriteObject.get("deny", or: "0")) ?? 0)
     }
 
     static func overwritesFromArray(_ permissionOverwritesArray: [[String: Any]]) -> [OverwriteID: DiscordPermissionOverwrite] {

--- a/Sources/SwiftDiscord/User/DiscordPresence.swift
+++ b/Sources/SwiftDiscord/User/DiscordPresence.swift
@@ -30,6 +30,9 @@ public struct DiscordPresence {
     /// The game this user is playing, if they are playing a game.
     public var game: DiscordActivity?
 
+    /// All of the user's current activies.
+    public var activities: [DiscordActivity]
+
     /// This user's nick on this guild.
     public var nick: String?
 
@@ -43,6 +46,7 @@ public struct DiscordPresence {
         self.guildId = guildId
         user = DiscordUser(userObject: presenceObject.get("user", or: [String: Any]()))
         game = DiscordActivity(gameObject: presenceObject["game"] as? [String: Any])
+        activities = (presenceObject["activities"] as? [[String: Any]])?.map(DiscordActivity.init(gameObject:)).compactMap { $0 } ?? []
         nick = presenceObject["nick"] as? String
         status = DiscordPresenceStatus(rawValue: presenceObject.get("status", or: "")) ?? .offline
         roles = []
@@ -53,6 +57,10 @@ public struct DiscordPresence {
             self.game = DiscordActivity(gameObject: game)
         } else {
             self.game = nil
+        }
+
+        if let activities = presenceObject["activities"] as? [[String: Any]] {
+            self.activities = activities.map(DiscordActivity.init(gameObject:)).compactMap { $0 }
         }
 
         if let nick = presenceObject["nick"] as? String {

--- a/Sources/SwiftDiscord/User/DiscordPresence.swift
+++ b/Sources/SwiftDiscord/User/DiscordPresence.swift
@@ -27,9 +27,6 @@ public struct DiscordPresence {
     /// The user associated with this presence.
     public let user: DiscordUser
 
-    /// The game this user is playing, if they are playing a game.
-    public var game: DiscordActivity?
-
     /// All of the user's current activies.
     public var activities: [DiscordActivity]
 
@@ -45,7 +42,6 @@ public struct DiscordPresence {
     init(presenceObject: [String: Any], guildId: GuildID) {
         self.guildId = guildId
         user = DiscordUser(userObject: presenceObject.get("user", or: [String: Any]()))
-        game = DiscordActivity(gameObject: presenceObject["game"] as? [String: Any])
         activities = (presenceObject["activities"] as? [[String: Any]])?.map(DiscordActivity.init(gameObject:)).compactMap { $0 } ?? []
         nick = presenceObject["nick"] as? String
         status = DiscordPresenceStatus(rawValue: presenceObject.get("status", or: "")) ?? .offline
@@ -53,12 +49,6 @@ public struct DiscordPresence {
     }
 
     mutating func updatePresence(presenceObject: [String: Any]) {
-        if let game = presenceObject["game"] as? [String: Any] {
-            self.game = DiscordActivity(gameObject: game)
-        } else {
-            self.game = nil
-        }
-
         if let activities = presenceObject["activities"] as? [[String: Any]] {
             self.activities = activities.map(DiscordActivity.init(gameObject:)).compactMap { $0 }
         }

--- a/Sources/SwiftDiscord/User/DiscordRole.swift
+++ b/Sources/SwiftDiscord/User/DiscordRole.swift
@@ -50,7 +50,7 @@ public struct DiscordRole : Encodable, Equatable {
         managed = roleObject.get("managed", or: false)
         mentionable = roleObject.get("mentionable", or: false)
         name = roleObject.get("name", or: "")
-        permissions = DiscordPermission(rawValue: roleObject.get("permissions", or: 0))
+        permissions = DiscordPermission(rawValue: Int(roleObject.get("permissions", or: "0")) ?? 0)
         position = roleObject.get("position", or: 0)
     }
 

--- a/Sources/SwiftDiscord/User/DiscordUserGuild.swift
+++ b/Sources/SwiftDiscord/User/DiscordUserGuild.swift
@@ -39,7 +39,7 @@ public struct DiscordUserGuild {
         name = userGuildObject.get("name", or: "")
         icon = userGuildObject.get("icon", or: "")
         owner = userGuildObject.get("owner", or: false)
-        permissions = DiscordPermission(rawValue: userGuildObject.get("permissions", or: 0))
+        permissions = DiscordPermission(rawValue: Int(userGuildObject.get("permissions", or: "0")) ?? 0)
     }
 
     static func userGuildsFromArray(_ guilds: [[String: Any]]) -> [GuildID: DiscordUserGuild] {

--- a/Tests/SwiftDiscordTests/Fixtures.swift
+++ b/Tests/SwiftDiscordTests/Fixtures.swift
@@ -95,7 +95,7 @@ let testGuildChannelCategory: [String: Any] = [
 let testGuild: [String: Any] = [
     "channels": [[String: Any]](),
     "default_message_notifications": 0,
-    "embed_enabled": false,
+    "widget_enabled": false,
     "embed_channel_id": "",
     "emojis": [[String: Any]](),
     "features": [Any](),

--- a/Tests/SwiftDiscordTests/Fixtures.swift
+++ b/Tests/SwiftDiscordTests/Fixtures.swift
@@ -96,7 +96,7 @@ let testGuild: [String: Any] = [
     "channels": [[String: Any]](),
     "default_message_notifications": 0,
     "widget_enabled": false,
-    "embed_channel_id": "",
+    "widget_channel_id": "",
     "emojis": [[String: Any]](),
     "features": [Any](),
     "icon": "",

--- a/Tests/SwiftDiscordTests/Fixtures.swift
+++ b/Tests/SwiftDiscordTests/Fixtures.swift
@@ -16,7 +16,7 @@ let testRole: [String: Any] = [
     "managed": false,
     "mentionable": true,
     "name": "My Test Role",
-    "permissions": 0,
+    "permissions": "0",
     "position": 0
 ]
 

--- a/Tests/SwiftDiscordTests/TestDiscordEngine.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordEngine.swift
@@ -52,7 +52,7 @@ public class TestDiscordEngine : XCTestCase, DiscordShardDelegate {
 
     public override func setUp() {
         loop = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        engine = DiscordEngine(delegate: self, onLoop: loop.next())
+        engine = DiscordEngine(delegate: self, intents: .unprivilegedIntents, onLoop: loop.next())
     }
 }
 

--- a/Tests/SwiftDiscordTests/TestDiscordGuild.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordGuild.swift
@@ -26,7 +26,7 @@ public class TestDiscordGuild : XCTestCase {
     }
 
     func testCreatingGuildSetsEmbedEnabled() {
-        tGuild["embed_enabled"] = true
+        tGuild["widget_enabled"] = true
 
         let guild = DiscordGuild(guildObject: tGuild, client: nil)
 

--- a/Tests/SwiftDiscordTests/TestDiscordGuild.swift
+++ b/Tests/SwiftDiscordTests/TestDiscordGuild.swift
@@ -25,20 +25,20 @@ public class TestDiscordGuild : XCTestCase {
         XCTAssertEqual(guild.defaultMessageNotifications, 0, "init should set default message notifications")
     }
 
-    func testCreatingGuildSetsEmbedEnabled() {
+    func testCreatingGuildSetsWidgetEnabled() {
         tGuild["widget_enabled"] = true
 
         let guild = DiscordGuild(guildObject: tGuild, client: nil)
 
-        XCTAssertTrue(guild.embedEnabled, "init should set embed enabled")
+        XCTAssertTrue(guild.widgetEnabled, "init should set widget enabled")
     }
 
-    func testCreatingGuildSetsEmbedChannel() {
-        tGuild["embed_channel_id"] = "200"
+    func testCreatingGuildSetsWidgetChannel() {
+        tGuild["widget_channel_id"] = "200"
 
         let guild = DiscordGuild(guildObject: tGuild, client: nil)
 
-        XCTAssertEqual(guild.embedChannelId, 200, "init should set the embed channel id")
+        XCTAssertEqual(guild.widgetChannelId, 200, "init should set the widget channel id")
     }
 
     func testCreatingGuildSetsIcon() {
@@ -229,8 +229,8 @@ public class TestDiscordGuild : XCTestCase {
             ("testCreatingGuildSetsId", testCreatingGuildSetsId),
             ("testCreatingGuildSetsName", testCreatingGuildSetsName),
             ("testCreatingGuildSetsDefaultMessageNotifications", testCreatingGuildSetsDefaultMessageNotifications),
-            ("testCreatingGuildSetsEmbedEnabled", testCreatingGuildSetsEmbedEnabled),
-            ("testCreatingGuildSetsEmbedChannel", testCreatingGuildSetsEmbedChannel),
+            ("testCreatingGuildSetsWidgetEnabled", testCreatingGuildSetsWidgetEnabled),
+            ("testCreatingGuildSetsWidgetChannel", testCreatingGuildSetsWidgetChannel),
             ("testCreatingGuildSetsIcon", testCreatingGuildSetsIcon),
             ("testCreatingGuildSetsLarge", testCreatingGuildSetsLarge),
             ("testCreatingGuildSetsMemberCount", testCreatingGuildSetsMemberCount),


### PR DESCRIPTION
This applies the changes [as documented here](https://github.com/discord/discord-api-docs/blob/master/docs/Change_Log.md#api-and-gateway-v8):

* [x] Add gateway intents
* [x] Migrate to new permissions
* [x] Remove `game` field from presence
* [x] Update channel permission overwrites
* [x] Migrate `embed_enabled` and `embed_channel_id` to `widget_enabled` and `widget_channel_id`
* [x] Migrate to floating point rate limits

Some nice-to-haves:

* [x] Support for allowed mentions
* [x] Support for message replies
* [x] Support for message stickers