### PR TITLE
Replace deprecated protocol class bounds with `AnyObject`

### DIFF
--- a/Sources/SwiftDiscord/DiscordClientDelegate.swift
+++ b/Sources/SwiftDiscord/DiscordClientDelegate.swift
@@ -19,7 +19,7 @@
 /// Declares that a type will be a delegate for a `DiscordClient`. After the client handles any events,
 /// the corresponding delegate method will be called.
 ///
-public protocol DiscordClientDelegate : class {
+public protocol DiscordClientDelegate : AnyObject {
     // MARK: Methods
 
     ///

--- a/Sources/SwiftDiscord/Voice/DiscordVoiceDataSource.swift
+++ b/Sources/SwiftDiscord/Voice/DiscordVoiceDataSource.swift
@@ -23,7 +23,7 @@ import Logging
 fileprivate let logger = Logger(label: "DiscordVoiceDataSource")
 
 /// Specifies that a type will be a data source for a VoiceEngine.
-public protocol DiscordVoiceDataSource : class {
+public protocol DiscordVoiceDataSource : AnyObject {
     // MARK: Properties
 
     /// The size of a frame in samples per channel. Needed to calculate the maximum size of a frame.


### PR DESCRIPTION
Using the `class` keyword for protocol inheritance is deprecated in
Swift 5.4.