### PR TITLE
Add support for message buttons

### DIFF
--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -937,6 +937,8 @@ public struct DiscordMessageComponent : Encodable {
 
     /// The type of the component.
     public let type: DiscordMessageComponentType
+    /// Sub-components. Only valid for action rows.
+    public let components: [DiscordMessageComponent]?
     /// One of a few button styles. Only valid for buttons.
     public let style: DiscordMessageComponentButtonStyle?
     /// Label that appears on a button. Only valid for buttons.
@@ -952,6 +954,7 @@ public struct DiscordMessageComponent : Encodable {
 
     public init(
         type: DiscordMessageComponentType,
+        components: [DiscordMessageComponent]? = nil,
         style: DiscordMessageComponentButtonStyle? = nil,
         label: String? = nil,
         emoji: DiscordMessageComponentEmoji? = nil,
@@ -960,12 +963,41 @@ public struct DiscordMessageComponent : Encodable {
         disabled: Bool? = nil
     ) {
         self.type = type
+        self.components = components
         self.style = style
         self.label = label
         self.emoji = emoji
         self.customId = customId
         self.url = url
         self.disabled = disabled
+    }
+
+    /// Creates a new button component.
+    public static func button(
+        style: DiscordMessageComponentButtonStyle? = nil,
+        label: String? = nil,
+        emoji: DiscordMessageComponentEmoji? = nil,
+        customId: String? = nil,
+        url: URL? = nil,
+        disabled: Bool? = nil
+    ) -> DiscordMessageComponent {
+        DiscordMessageComponent(
+            type: .button,
+            style: style,
+            label: label,
+            emoji: emoji,
+            customId: customId,
+            url: url,
+            disabled: disabled
+        )
+    }
+
+    /// Creates a new action row component. Cannot contain other action rows.
+    public static func actionRow(components: [DiscordMessageComponent]) -> DiscordMessageComponent {
+        DiscordMessageComponent(
+            type: .actionRow,
+            components: components
+        )
     }
 }
 

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -27,6 +27,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
             case embed
             case allowedMentions = "allowed_mentions"
             case messageReference = "message_reference"
+            case components
         }
 
         let content: String
@@ -34,6 +35,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         let embed: DiscordEmbed?
         let allowedMentions: DiscordAllowedMentions?
         let messageReference: DiscordMessageReference?
+        let components: [DiscordMessageComponent]?
     }
 
     // MARK: Typealiases
@@ -248,7 +250,14 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     // MARK: Methods
 
     func createDataForSending() -> Either<Data, (boundary: String, body: Data)> {
-        let fields = FieldsList(content: content, tts: tts, embed: embeds.first, allowedMentions: allowedMentions, messageReference: messageReference)
+        let fields = FieldsList(
+            content: content,
+            tts: tts,
+            embed: embeds.first,
+            allowedMentions: allowedMentions,
+            messageReference: messageReference,
+            components: components
+        )
         let fieldsData = JSON.encodeJSONData(fields) ?? Data()
         if files.count > 0 {
             return .right(createMultipartBody(encodedJSON: fieldsData, files: files))
@@ -928,6 +937,7 @@ public struct DiscordMessageReference : Encodable {
 public struct DiscordMessageComponent : Encodable {
     public enum CodingKeys : String, CodingKey {
         case type
+        case components
         case style
         case label
         case emoji

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -1012,7 +1012,7 @@ public struct DiscordMessageComponent : Encodable {
     }
 }
 
-public struct DiscordMessageComponentType : RawRepresentable, Encodable {
+public struct DiscordMessageComponentType : RawRepresentable, Hashable, Encodable {
     public let rawValue: Int
 
     public static let actionRow = DiscordMessageComponentType(rawValue: 1)
@@ -1036,7 +1036,7 @@ public struct DiscordMessageComponentEmoji : Encodable {
     }
 }
 
-public struct DiscordMessageComponentButtonStyle : RawRepresentable, Encodable {
+public struct DiscordMessageComponentButtonStyle : RawRepresentable, Hashable, Encodable {
     public let rawValue: Int
 
     public static let primary = DiscordMessageComponentButtonStyle(rawValue: 1)

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -119,6 +119,9 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     /// A referenced message in an outgoing message.
     public let messageReference: DiscordMessageReference?
 
+    /// Interactive components (e.g. buttons) in the message
+    public let components: [DiscordMessageComponent]?
+
     /// The type of this message.
     public let type: MessageType
 
@@ -161,6 +164,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         allowedMentions = nil
         referencedMessage = messageObject.get("referenced_message", as: [String: Any].self)
         messageReference = nil
+        components = nil
         files = []
         type = MessageType(rawValue: messageObject.get("type", or: 0)) ?? .default
         self.client = client
@@ -174,7 +178,15 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     /// - parameter files: The files to send with this message.
     /// - parameter tts: Whether this message should be text-to-speach.
     ///
-    public init(content: String, embed: DiscordEmbed? = nil, files: [DiscordFileUpload] = [], tts: Bool = false, allowedMentions: DiscordAllowedMentions? = nil, messageReference: DiscordMessageReference? = nil) {
+    public init(
+        content: String,
+        embed: DiscordEmbed? = nil,
+        files: [DiscordFileUpload] = [],
+        tts: Bool = false,
+        allowedMentions: DiscordAllowedMentions? = nil,
+        messageReference: DiscordMessageReference? = nil,
+        components: [DiscordMessageComponent] = []
+    ) {
         self.content = content
         if let embed = embed {
             self.embeds = [embed]
@@ -187,6 +199,7 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
         self.tts = tts
         self.allowedMentions = allowedMentions
         self.messageReference = messageReference
+        self.components = components
         self.referencedMessage = nil
         self.attachments = []
         self.author = DiscordUser(userObject: [:])
@@ -907,6 +920,90 @@ public struct DiscordMessageReference : Encodable {
         self.messageId = messageId
         self.channelId = channelId
         self.guildId = guildId
+    }
+}
+
+/// An interactive part of a message.
+public struct DiscordMessageComponent : Encodable {
+    public enum CodingKeys : String, CodingKey {
+        case type
+        case style
+        case label
+        case emoji
+        case customId = "custom_id"
+        case url
+        case disabled
+    }
+
+    /// The type of the component.
+    public let type: DiscordMessageComponentType
+    /// One of a few button styles. Only valid for buttons.
+    public let style: DiscordMessageComponentButtonStyle?
+    /// Label that appears on a button. Only valid for buttons.
+    public let label: String?
+    /// Emoji that appears on the button. Only valid for buttons.
+    public let emoji: DiscordMessageComponentEmoji?
+    /// A developer-defined id for the button, max 100 chars. Only valid for buttons.
+    public let customId: String?
+    /// A URL for link-style buttons. Only valid for buttons.
+    public let url: URL?
+    /// Whether the button is disabled. False by default. Only valid for buttons.
+    public let disabled: Bool?
+
+    public init(
+        type: DiscordMessageComponentType,
+        style: DiscordMessageComponentButtonStyle? = nil,
+        label: String? = nil,
+        emoji: DiscordMessageComponentEmoji? = nil,
+        customId: String? = nil,
+        url: URL? = nil,
+        disabled: Bool? = nil
+    ) {
+        self.type = type
+        self.style = style
+        self.label = label
+        self.emoji = emoji
+        self.customId = customId
+        self.url = url
+        self.disabled = disabled
+    }
+}
+
+public struct DiscordMessageComponentType : RawRepresentable, Encodable {
+    public let rawValue: Int
+
+    public static let actionRow = DiscordMessageComponentType(rawValue: 1)
+    public static let button = DiscordMessageComponentType(rawValue: 2)
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}
+
+/// A partial emoji for use in message components.
+public struct DiscordMessageComponentEmoji : Encodable {
+    public let id: EmojiID?
+    public let name: String?
+    public let animated: Bool
+
+    public init(id: EmojiID? = nil, name: String? = nil, animated: Bool = false) {
+        self.id = id
+        self.name = name
+        self.animated = animated
+    }
+}
+
+public struct DiscordMessageComponentButtonStyle : RawRepresentable, Encodable {
+    public let rawValue: Int
+
+    public static let primary = DiscordMessageComponentButtonStyle(rawValue: 1)
+    public static let secondary = DiscordMessageComponentButtonStyle(rawValue: 2)
+    public static let success = DiscordMessageComponentButtonStyle(rawValue: 3)
+    public static let danger = DiscordMessageComponentButtonStyle(rawValue: 4)
+    public static let link = DiscordMessageComponentButtonStyle(rawValue: 5)
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
     }
 }
 

--- a/Sources/SwiftDiscord/Channel/DiscordMessage.swift
+++ b/Sources/SwiftDiscord/Channel/DiscordMessage.swift
@@ -119,7 +119,8 @@ public struct DiscordMessage : DiscordClientHolder, ExpressibleByStringLiteral {
     /// A referenced message in an outgoing message.
     public let messageReference: DiscordMessageReference?
 
-    /// Interactive components (e.g. buttons) in the message
+    /// Interactive components in the message. This top-level array should only
+    /// contain action rows (which can then e.g. contain buttons).
     public let components: [DiscordMessageComponent]?
 
     /// The type of this message.

--- a/Sources/SwiftDiscord/Interaction/DiscordApplicationCommand.swift
+++ b/Sources/SwiftDiscord/Interaction/DiscordApplicationCommand.swift
@@ -167,12 +167,16 @@ public struct DiscordApplicationCommandInteractionData {
     /// The name of the invoked command
     public let name: String
 
+    /// A custom (developer-defined) id attached to e.g. a button interaction.
+    public let customId: String?
+
     /// The params + values by the user
     public let options: [DiscordApplicationCommandInteractionDataOption]
 
     init(dataObject: [String: Any]) {
         id = Snowflake(dataObject["id"] as? String) ?? 0
         name = dataObject.get("name", as: String.self) ?? ""
+        customId = dataObject["custom_id"] as? String
         options = (dataObject["options"] as? [[String: Any]])?.map(DiscordApplicationCommandInteractionDataOption.init(optionObject:)).compactMap { $0 } ?? []
     }
 }

--- a/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
+++ b/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
@@ -47,7 +47,7 @@ public struct DiscordInteraction {
     }
 }
 
-public struct DiscordInteractionType: RawRepresentable {
+public struct DiscordInteractionType: RawRepresentable, Hashable {
     public var rawValue: Int
 
     public static let ping = DiscordInteractionType(rawValue: 1)

--- a/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
+++ b/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
@@ -18,6 +18,9 @@ public struct DiscordInteraction {
     /// The message a user interacted with, e.g. when pressing a button.
     public let message: DiscordMessage?
 
+    /// A custom (developer-defined) id attached to e.g. a button interaction.
+    public let customId: String?
+
     /// Guild it was sent from
     public let guildId: GuildID
 
@@ -38,6 +41,7 @@ public struct DiscordInteraction {
         type = (interactionObject["type"] as? Int).flatMap(DiscordInteractionType.init(rawValue:))
         data = (interactionObject["data"] as? [String: Any]).map(DiscordApplicationCommandInteractionData.init(dataObject:))
         message = (interactionObject["message"] as? [String: Any]).map { DiscordMessage(messageObject: $0, client: nil) }
+        customId = interactionObject["custom_id"] as? String
         let guildId = Snowflake(interactionObject["guild_id"] as? String) ?? 0
         self.guildId = guildId
         channelId = Snowflake(interactionObject["channel_id"] as? String) ?? 0

--- a/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
+++ b/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
@@ -15,6 +15,9 @@ public struct DiscordInteraction {
     /// types, but optional for future-proofing.
     public let data: DiscordApplicationCommandInteractionData?
 
+    /// The message a user interacted with, e.g. when pressing a button.
+    public let message: DiscordMessage?
+
     /// Guild it was sent from
     public let guildId: GuildID
 
@@ -34,6 +37,7 @@ public struct DiscordInteraction {
         id = Snowflake(interactionObject["id"] as? String) ?? 0
         type = (interactionObject["type"] as? Int).flatMap(DiscordInteractionType.init(rawValue:))
         data = (interactionObject["data"] as? [String: Any]).map(DiscordApplicationCommandInteractionData.init(dataObject:))
+        message = (interactionObject["message"] as? [String: Any]).map { DiscordMessage(messageObject: $0, client: nil) }
         let guildId = Snowflake(interactionObject["guild_id"] as? String) ?? 0
         self.guildId = guildId
         channelId = Snowflake(interactionObject["channel_id"] as? String) ?? 0

--- a/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
+++ b/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
@@ -43,7 +43,14 @@ public struct DiscordInteraction {
     }
 }
 
-public enum DiscordInteractionType: Int {
-    case ping = 1
-    case applicationCommand = 2
+public struct DiscordInteractionType: RawRepresentable {
+    public var rawValue: Int
+
+    public static let ping = DiscordInteractionType(rawValue: 1)
+    public static let applicationCommand = DiscordInteractionType(rawValue: 2)
+    public static let messageComponent = DiscordInteractionType(rawValue: 3)
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
+++ b/Sources/SwiftDiscord/Interaction/DiscordInteraction.swift
@@ -18,9 +18,6 @@ public struct DiscordInteraction {
     /// The message a user interacted with, e.g. when pressing a button.
     public let message: DiscordMessage?
 
-    /// A custom (developer-defined) id attached to e.g. a button interaction.
-    public let customId: String?
-
     /// Guild it was sent from
     public let guildId: GuildID
 
@@ -41,7 +38,6 @@ public struct DiscordInteraction {
         type = (interactionObject["type"] as? Int).flatMap(DiscordInteractionType.init(rawValue:))
         data = (interactionObject["data"] as? [String: Any]).map(DiscordApplicationCommandInteractionData.init(dataObject:))
         message = (interactionObject["message"] as? [String: Any]).map { DiscordMessage(messageObject: $0, client: nil) }
-        customId = interactionObject["custom_id"] as? String
         let guildId = Snowflake(interactionObject["guild_id"] as? String) ?? 0
         self.guildId = guildId
         channelId = Snowflake(interactionObject["channel_id"] as? String) ?? 0


### PR DESCRIPTION
The Discord API has recently added support for message components, most notably buttons:

![image](https://user-images.githubusercontent.com/30873659/120123748-fc865900-c1b0-11eb-9890-73bf55cc129f.png)

See the docs for more info: https://discord.com/developers/docs/interactions/message-components